### PR TITLE
feat: mark the moments a recording's picture changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,13 +76,33 @@ jobs:
       # A green `just check` is not enough on its own: a skipped test and a
       # passing test look identical in an exit code. Assert the count so a
       # missing system dependency cannot quietly shrink the suite again.
+      # An exact count stood here -- `116 passed, 11 deselected` -- and it was
+      # WRONG almost immediately. It went stale the first time a test was added
+      # and CI went red on main on 2026-08-06 reporting "something skipped" for
+      # a run with 129 passed and zero skipped. A guard that cries wolf on every
+      # legitimate addition gets muted, which would cost the real signal.
+      #
+      # So assert the INVARIANT rather than a magic number. The hazard is a
+      # skipped test looking like a passing one -- the first green run here was
+      # "102 passed, 14 skipped" with ffmpeg missing and the whole ingestion
+      # boundary unexercised. `skipped` appearing at all is that hazard, exactly,
+      # and needs no maintenance. The floor catches the other direction, a suite
+      # that shrinks; raise it when tests are added, and note that forgetting to
+      # is harmless where forgetting to bump an exact count was not.
       - name: no test may silently skip
         run: |
           # NOT `pytest -q`: addopts already carries -q, so a second one
           # makes -qq and pytest suppresses the summary line entirely --
           # the guard then fails on a run where nothing was wrong.
           uv run pytest 2>&1 | tail -3 | tee /tmp/summary
-          grep -qE '^116 passed, 11 deselected' /tmp/summary || {
-            echo "::error::fast lane is not 116 passed / 11 deselected -- something skipped"
+          # `if`, not `grep && { }`: the shell runs with -e, and a compound
+          # ending in a failed grep would abort the step on the healthy path.
+          if grep -q 'skipped' /tmp/summary; then
+            echo "::error::a test SKIPPED -- a system dependency is missing on the runner"
             exit 1
-          }
+          fi
+          passed=$(grep -oE '[0-9]+ passed' /tmp/summary | grep -oE '^[0-9]+')
+          if [ "${passed:-0}" -lt 176 ]; then
+            echo "::error::fast lane is ${passed:-no} passed, floor is 176 -- the suite shrank"
+            exit 1
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,15 @@
 scratch/*
 !scratch/*.py
 !scratch/*.sh
+# One level down too. `scratch/*` stops git descending into a subdirectory at
+# all, so a probe filed under scratch/vlm/ was silently untrackable -- the
+# exact "an untracked check is a check nobody runs" failure this block exists
+# to prevent, reappearing one directory deeper. Re-ignore the contents, then
+# carve the code back out.
+!scratch/*/
+scratch/*/*
+!scratch/*/*.py
+!scratch/*/*.sh
 
 .venv/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ in the meeting and, as text, it is worthless. The referent was on screen.
 | | |
 |---|---|
 | **Transcript half** | working — ingestion, chunked ASR, resume, optional speaker labels |
-| **Retrieval half** | **not built.** No frame extraction, no vision model. See [Roadmap](#roadmap) |
+| **Visual marks** | working — the moments the picture changed, written into the transcript. No description attached |
+| **Frame description** | **not built**, and now blocked on a *measured* finding rather than an unmeasured one. See [Roadmap](#roadmap) |
 
-So today deixis is a resumable, observable transcriber whose output is designed
-to be indexed against. The half that answers *"see this column here"* is the
-work ahead, and it is blocked on a measurement, not on code — see
-[Roadmap](#roadmap).
+So today deixis is a resumable, observable transcriber that also tells you
+*when* to look. The half that says *what* you would see — answering "see this
+column here" — is the work ahead.
 
 ---
 
@@ -90,6 +90,30 @@ chunk. Re-running the same command resumes from it; a changed model, source
 file, or chunk geometry invalidates it automatically and the run starts over
 rather than reusing tokens that describe something else.
 
+### Visual marks
+
+A second pass adds the timestamps where the picture changed most. It is
+separate because the transcript arrives at ~13x realtime and this decodes every
+sampled frame at ~10x, so coupling them would make the fast half wait:
+
+```bash
+uv run python -m deixis.frames recording.mov -t transcript.json
+```
+
+| Flag | |
+|---|---|
+| `-t, --transcript PATH` | the transcript to add marks to (required) |
+| `-o, --out PATH` | write elsewhere instead of overwriting `--transcript` |
+| `--budget N` | how many marks to keep (default 150) |
+| `--min-gap SECONDS` | how far apart they must be (default 5) |
+| `--fps N` | frames sampled per second of video (default 1) |
+| `--delta N` | grey levels a tile must move to count (default 8) |
+
+`--budget` rather than a sensitivity threshold is the one design decision worth
+knowing about, and it is not a preference — three threshold-based detectors were
+built and measured against a real recording before this one, and all three
+failed. [docs/visual-marks.md](docs/visual-marks.md) has the numbers.
+
 ## Output
 
 ```jsonc
@@ -107,7 +131,12 @@ rather than reusing tokens that describe something else.
       "text": " See this column here.",
       "tokens": [{"t": 12.34, "w": " See"}, {"t": 12.51, "w": " this"}]
     }
-  ]
+  ],
+
+  // added by `python -m deixis.frames`; absent until that pass has run
+  "marks": [{"t": 417.0, "score": 2841}],
+  "marks_meta": {"budget": 150, "min_gap_s": 5.0, "fps": 1.0, "delta": 8,
+                 "grid": [128, 84], "frames_sampled": 1997, "source": "..."}
 }
 ```
 
@@ -119,6 +148,11 @@ Two things about this shape are deliberate:
   invites you to treat it as an identity.
 - **`diarization` is absent when the pass did not run.** Without that, "no
   diarization" and "diarization found one speaker" are the same document.
+- **`marks` sits beside `sentences`, not inside them.** A mark is a fact about
+  the video at a time, not about a sentence; nesting it in whichever sentence
+  happens to span that second would invent a relationship nothing observed.
+  `marks_meta` travels with it for the same reason `diarization` does — marks
+  from a budget of 150 and marks from a budget of 20 are different documents.
 
 ## Development
 
@@ -139,6 +173,8 @@ can fail. That cost is the point — see [docs/tooling-gaps.md](docs/tooling-gap
 | [docs/tooling-gaps.md](docs/tooling-gaps.md) | the practices and tools this project is built to, written out of an audit where five defects shipped past a green suite |
 | [docs/resume-gate-design.md](docs/resume-gate-design.md) | how you test a resume that silently restarts, given it produces byte-identical output |
 | [docs/mutmut-triage.md](docs/mutmut-triage.md) | every surviving mutant and why it is accepted |
+| [docs/visual-marks.md](docs/visual-marks.md) | the three change detectors that were built and measured before this one, and why each failed |
+| [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Measured: not this one |
 
 ---
 
@@ -161,11 +197,17 @@ video length.
 
 This inverts the usual pipeline. Scene-detect-then-OCR-everything is a **push**
 design: extract all visual content upfront, pay for it whether or not any of it
-mattered, then try to compress. It also drowns in false positives — cursor
-movement and scrolling trip content-based scene detection constantly on a
-screen-share. Transcript-driven retrieval never enumerates scenes at all, and the
-"which of these 60 frames mattered?" judgement is answered by the speaker, out
-loud, at a known timestamp.
+mattered, then try to compress.
+
+The false-positive half of that argument turned out to be **measurably true** —
+a perceptual-hash detector fired on cursor movement alone on a real recording,
+which is exactly what was predicted here before anyone had run one. The
+conclusion drawn from it was too strong, though. Visual marks *do* enumerate the
+video, and cheaply: ranking every sampled frame costs 33 ms of arithmetic on top
+of a decode, and produces 150 timestamps and no descriptions. Enumerating is not
+what makes the push design expensive; **describing** everything you enumerated
+is. Marks are a table of contents, and the transcript still decides which
+entries are worth opening.
 
 ### Decisions made so far
 
@@ -219,11 +261,15 @@ inventing invalidation and leaving 135 MB files next to the user's recordings.
 Anyone who wants the wav can extract it by hand and pass it — the conversion
 step is skipped when the input is already mono `pcm_s16le` at the model's rate.
 
-**Vision, not OCR — `mlx-vlm` + Qwen2.5-VL-7B-Instruct (4-bit, ~5-6GB RAM).**
-Qwen2.5-VL leads DocVQA (96.4% at 72B, near the ~98.1% human ceiling) and scores
-89.5% on ChartQA. `mlx-vlm` is very actively maintained. Fallback for missed
-chart/table detail is Qwen3-VL-30B-A3B-Thinking at ~18-20GB, which needs a 64GB
-machine.
+**Vision, not OCR — but which vision model is now an open question.**
+The plan named Qwen2.5-VL-7B-Instruct on `mlx-vlm`, on the strength of published
+DocVQA and ChartQA scores. That model has still never been run here. What *has*
+been run is `gemma-4-e2b-it-4bit`, on five frames from a real recording with
+ground truth written down first: 47% recall and 18 fabricated strings, at
+18-22 s per image. Benchmark leadership on document QA did not survive contact
+with a screenshot of an inbox — see
+[docs/vlm-legibility.md](docs/vlm-legibility.md) — so the model choice is
+deliberately reopened rather than carried forward.
 
 **Speaker labels: senko, optional, and wrong in ways worth naming.**
 Diarization is an extra — `uv sync --extra diarize` — not a dependency. It pulls
@@ -288,30 +334,45 @@ whose ground truth is two speakers:
 
 ## Roadmap
 
-The transcript half is done. The retrieval half is not, and it is blocked on a
-**measurement rather than on code**:
+Frame *selection* is answered. Frame *description* is not.
 
-- **Frame dedup has no validated method for screen content.** Searching
-  "screencast keyframe extraction", "slide change detection", "lecture video
-  segmentation", "screen recording deduplication" turns up only generic
-  luminance-shift academic work and abandoned repos. Confirmed gap.
-  - Planned shape is two-stage: cheap pHash pre-filter, then a DINOv2 cosine
-    gate for "is this actually new information".
-  - The pHash threshold everyone cites (Hamming ≤8) is calibrated on natural
-    photos, never on text-heavy UI. Worse, pHash discards *high-frequency*
-    detail — precisely what separates two states of the same spreadsheet. Expect
-    it to under-trigger on "same doc, different cell selected".
-  - DINOv2 over CLIP because it is image-only self-supervised, so there is no
-    text-conditioning to collapse every "spreadsheet-shaped" image together. One
-    report puts DINOv2-ViT-B/14 at ~93% on document/screenshot duplicate
-    detection, ahead of CLIP. **But no published benchmark tests discrimination
-    between two different spreadsheets.** Nothing here is trustworthy until
-    measured on our own data.
-- **Therefore the first build task is an eval set**, not a feature: 50-100 hand-
-  labelled frame pairs from real recordings ("same information" / "new
-  information"). No threshold means anything without it.
+**What the selection work settled** (numbers and method in
+[docs/visual-marks.md](docs/visual-marks.md)):
+
+- The pHash worry recorded here previously was right about the symptom and
+  wrong about the direction. A 9x8 dHash did not under-trigger on "same doc,
+  different cell" — it fired on **pointer movement alone** and missed a ticked
+  checkbox, because 327x239-pixel cells resolve nothing smaller than a window
+  switch. ffmpeg's `mpdecimate`, the standard duplicate dropper, failed the
+  opposite way and kept 1997 of 1997 frames.
+- The deeper finding is that **no threshold can work**, on any detector: during
+  an active session the screen changes most seconds, so "the screen changed" is
+  not a rare event and cannot be an index. Ranking under a fixed budget replaces
+  it and needs no per-video tuning.
+- **No eval set was needed.** The plan called for 50–100 hand-labelled frame
+  pairs before anything could be trusted. A budget has no threshold to
+  calibrate, so the thing the eval set existed to justify does not exist. Two
+  synthetic controls — a static video that must yield nothing, a two-cut video
+  that must yield exactly its two cuts — pin the behaviour instead.
+- **DINOv2 was not needed either**, and the reason is cheaper than expected:
+  mean-pooling on the way down to a 128x84 grid already suppresses smooth motion
+  (webcam tiles, faces) while keeping the high-contrast edges of text and UI.
+
+**What blocks description**, now measured rather than assumed
+([docs/vlm-legibility.md](docs/vlm-legibility.md)):
+
+- `gemma-4-e2b-it-4bit` recovered 33 of 70 hand-written ground-truth strings
+  across five real frames (47%) while fabricating 18 — and the fabrications are
+  fluent, plausible UI text (`Your GPS aren't the problem`, `OpenAI Browser`),
+  which is the kind that poisons an index silently. Resolution is not the fix:
+  700 → 1600 px moved recall by one string.
+- It is also 18–22 s per image, not the ~5 s assumed from an earlier benchmark
+  whose outputs were 23–26 tokens long.
+- Untested and worth trying before concluding anything general: a larger local
+  model (`Qwen3-VL-4B`), a terse prompt with a larger token budget, and a cloud
+  VLM — none of which have been run.
 - **ColPali / ColQwen2** (late-interaction retrieval over page images, no OCR)
-  is the interesting phase-2 option, but no MLX port exists and nobody reports
+  remains the interesting alternative, but no MLX port exists and nobody reports
   running `colpali-engine` on Apple Silicon MPS. Experiment, not infrastructure.
 
 ### Prior art
@@ -327,6 +388,7 @@ are OCR-based, which is the approach this tool rejects.
 deixis/            the package
   media.py         ffmpeg ingestion, with progress and actionable errors
   transcribe.py    the CLI and the orchestration
+  frames.py        the moments the picture changed, ranked under a budget
   chunking.py      the chunk loop parakeet-mlx does not provide
   checkpoint.py    resume, and the validated boundary that reads it
   merge.py         token-vote speaker labelling

--- a/deixis/frames.py
+++ b/deixis/frames.py
@@ -1,0 +1,355 @@
+"""Find the moments the screen changed, and write them into the transcript.
+
+The transcript indexes what was said. This indexes what was shown: a bounded
+list of timestamps where the picture moved enough to be worth a look. Nothing
+here describes a frame -- a mark says "something happened at t", which is
+enough to make the video navigable and costs no tokens at all.
+
+WHY A BUDGET AND NOT A THRESHOLD. The obvious design is "mark every frame whose
+change score crosses a threshold", and it was built and measured first. It does
+not work, for a reason that is a property of the content rather than of the
+detector: during an active working session the screen changes MOST seconds. On
+the 33-minute reference recording the median one-second interval already moves
+38 tiles, and a sweep of 54 threshold configurations could not find one that
+marked a ticked checkbox without also marking a frame where nothing moved but
+the mouse pointer. "The screen changed" is not a rare event, so it cannot be an
+index -- a marker is only worth reading because it is uncommon.
+
+Ranking sidesteps this. Score every interval, take the largest `budget` of
+them, and keep them apart by `min_gap_s`. The output is bounded and useful
+whatever the content: a static lecture yields well-separated marks at each
+slide, a frantic screen-share yields the biggest transitions in it. No
+per-video tuning, and no threshold to be wrong about.
+
+WHY TILE COUNTS AND NOT A PERCEPTUAL HASH. Every off-the-shelf tool for this
+(video-sampler, videostil, framewise, PySceneDetect's detect-hash) reduces a
+frame to one 64-bit hash and compares Hamming distances. Measured on the
+reference recording, a 9x8 dHash resolves 327x239-pixel cells -- coarse enough
+to see an application switch and nothing smaller. It fired on pointer movement
+alone and missed a ticked checkbox. Counting changed tiles on a finer grid
+keeps the spatial information the hash throws away, and the count itself is the
+magnitude the ranking needs; a Hamming distance is not one.
+
+The mean-pooling ffmpeg does on the way down is load-bearing rather than
+incidental. Averaging a ~23x23-pixel tile flattens smooth low-contrast motion
+-- a webcam tile, a face -- while preserving the thin high-contrast edges that
+text and UI chrome are made of. That is the behaviour the screen-content image
+hashing literature prescribes deliberately, and here it falls out of the
+downscale for free: on the reference recording the busiest rows are the browser
+content, not the video-call tiles.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "DEFAULT_BUDGET",
+    "DEFAULT_DELTA",
+    "DEFAULT_FPS",
+    "DEFAULT_MIN_GAP_S",
+    "GRID_H",
+    "GRID_W",
+    "Mark",
+    "change_scores",
+    "main",
+    "mark_video",
+    "select_marks",
+    "with_marks",
+]
+
+import json
+import logging
+import sys
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+import numpy as np
+
+from deixis import media as media_mod
+from deixis.atomic import atomic_write_text
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from numpy.typing import NDArray
+
+type Payload = dict[str, Any]
+
+logger = logging.getLogger("deixis.frames")
+
+# 128x84 over a 2940x1912 source is ~23x23-pixel tiles. Chosen by sweep, not by
+# taste: 32x21 was too coarse to see a form scroll, and 128x84 costs 518s of
+# decode against 205s for a 9x8 grid on the reference recording -- ffmpeg's
+# scaler, not the arithmetic, which is 33ms for the whole 33 minutes.
+GRID_W = 128
+GRID_H = 84
+
+# One frame per second. The reference recording is 36 fps; at 1 fps a 33-minute
+# file is 1,997 samples, and the marks it produces are already closer together
+# (median 9s) than any reader wants. Sampling faster buys resolution nobody has
+# asked for and costs decode time linearly.
+DEFAULT_FPS = 1.0
+
+# A tile counts as changed when its mean grey level moves by more than this.
+# 8/255 sits above sensor and compression noise and below a text redraw.
+DEFAULT_DELTA = 8
+
+# 150 marks is roughly one every 13 seconds of a 33-minute recording. The
+# weakest of the 150 picked on the reference file was inspected by eye and is a
+# real event (a form scrolled and saved), so the budget is if anything low.
+DEFAULT_BUDGET = 150
+
+# Two marks closer than this describe the same moment. Without it the ranking
+# spends its whole budget inside the busiest minute of the file; with it the
+# reference recording spreads 31/30/25/25/14/11 marks across its six five-minute
+# buckets.
+DEFAULT_MIN_GAP_S = 5.0
+
+
+class Mark(NamedTuple):
+    """One moment worth looking at.
+
+    `score` is the number of tiles that changed since the previous sample. It
+    is kept rather than dropped because it is the only thing distinguishing a
+    window switch from a scroll, and a consumer deciding which marks to spend a
+    VLM call on needs that ordering.
+    """
+
+    t: float
+    score: int
+
+
+def change_scores(tiles: NDArray[np.uint8], delta: int = DEFAULT_DELTA) -> NDArray[np.int32]:
+    """Count changed tiles between each consecutive pair of frames.
+
+    Args:
+        tiles: An (N, h, w) array of greyscale tile means, as
+            media.extract_tile_grid returns.
+        delta: Grey levels a tile must move by to count as changed.
+
+    Returns:
+        An (N-1,) array; element i is the count between frames i and i+1. Empty
+        when fewer than two frames were sampled, which is the honest answer for
+        a file too short to have an interval in it.
+
+    Raises:
+        ValueError: if `tiles` is not three-dimensional, or `delta` is
+            negative. A negative delta counts every tile as changed and would
+            produce a confident, uniform, meaningless ranking.
+    """
+    if tiles.ndim != 3:
+        raise ValueError(f"expected an (N, h, w) tile array, got shape {tiles.shape}")
+    if delta < 0:
+        raise ValueError(f"delta must be non-negative, got {delta}")
+    if len(tiles) < 2:
+        return np.zeros(0, dtype=np.int32)
+
+    # int16, not the uint8 the array arrives as: an unsigned subtraction wraps,
+    # so a tile going from 10 to 250 would read as a change of 16 rather than
+    # 240 -- the largest changes silently becoming the smallest.
+    diff = np.abs(tiles[1:].astype(np.int16) - tiles[:-1].astype(np.int16))
+    return (diff > delta).sum(axis=(1, 2)).astype(np.int32)
+
+
+def select_marks(
+    scores: NDArray[np.int32],
+    *,
+    fps: float = DEFAULT_FPS,
+    budget: int = DEFAULT_BUDGET,
+    min_gap_s: float = DEFAULT_MIN_GAP_S,
+) -> list[Mark]:
+    """Take the highest-scoring intervals, keeping them `min_gap_s` apart.
+
+    Greedy rather than optimal: walk the scores from largest down, keep one if
+    nothing already kept sits within `min_gap_s` of it, stop at `budget`. The
+    optimal spacing-constrained subset is a different and much slower problem,
+    and the difference between them is not visible in an index a human skims.
+
+    Args:
+        scores: Per-interval change counts from change_scores.
+        fps: The rate the frames were sampled at, which turns an index into a
+            timestamp.
+        budget: The most marks to return.
+        min_gap_s: Seconds two marks must be apart.
+
+    Returns:
+        Marks in ascending time order -- the order a reader wants, not the
+        ranked order the selection happened in. Fewer than `budget` when the
+        gap constraint or the supply of non-zero scores runs out first.
+
+    Raises:
+        ValueError: if `fps` is not positive, `budget` is negative, or
+            `min_gap_s` is negative.
+    """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}")
+    if budget < 0:
+        raise ValueError(f"budget must be non-negative, got {budget}")
+    if min_gap_s < 0:
+        raise ValueError(f"min_gap_s must be non-negative, got {min_gap_s}")
+
+    # Stable, so equal scores are taken earliest-first and two runs over the
+    # same file cannot disagree. numpy's default quicksort is not stable and
+    # would make the output depend on the array's memory layout.
+    order = np.argsort(-scores, kind="stable")
+
+    picked: list[int] = []
+    for i in order:
+        if len(picked) >= budget:
+            break
+        # A zero score is a frame identical to its predecessor. Padding the
+        # budget with those would put marks on nothing at all, which is worse
+        # than returning fewer.
+        if scores[i] <= 0:
+            break
+        idx = int(i)
+        if all(abs(idx - p) * (1.0 / fps) >= min_gap_s for p in picked):
+            picked.append(idx)
+
+    # i indexes the interval between frames i and i+1, so the change is visible
+    # at frame i+1 and that is the timestamp worth seeking to.
+    return sorted(Mark(t=(i + 1) / fps, score=int(scores[i])) for i in picked)
+
+
+def with_marks(payload: Payload, marks: list[Mark], meta: dict[str, Any]) -> Payload:
+    """Return `payload` with visual marks added, leaving the original alone.
+
+    A copy rather than a mutation: the caller's transcript is on disk and may
+    be read again, and a function that edits its argument in place makes a
+    partial failure halfway through unrecoverable.
+
+    `marks` lands as a sibling of `sentences` rather than being distributed
+    into them. A mark is a fact about the video at a time, not about a
+    sentence; nesting it inside whichever sentence happens to span that second
+    would invent a relationship the detector never observed.
+    """
+    out = dict(payload)
+    out["marks"] = [{"t": round(m.t, 3), "score": m.score} for m in marks]
+    # The parameters travel with the result. Marks from a budget of 150 and
+    # marks from a budget of 20 are different documents, and a reader with only
+    # the list cannot tell which one they have.
+    out["marks_meta"] = meta
+    return out
+
+
+def mark_video(
+    media: Path,
+    transcript: Path,
+    out: Path,
+    *,
+    fps: float = DEFAULT_FPS,
+    delta: int = DEFAULT_DELTA,
+    budget: int = DEFAULT_BUDGET,
+    min_gap_s: float = DEFAULT_MIN_GAP_S,
+    on_progress: Callable[[float], None] | None = None,
+) -> Payload:
+    """Decode `media`, rank its changes, and write `transcript` + marks to `out`.
+
+    A separate pass over the video rather than a step inside transcribe(). The
+    transcript is worth having on its own and arrives at ~35x realtime; this
+    decodes every sampled frame and runs at ~4x. Coupling them would make the
+    fast half wait for the slow one.
+
+    Raises:
+        FileNotFoundError: if `transcript` does not exist. Marks index a
+            transcript; there is nothing to add them to otherwise.
+    """
+    if not transcript.exists():
+        raise FileNotFoundError(transcript)
+    payload: Payload = json.loads(transcript.read_text())
+
+    tiles = media_mod.extract_tile_grid(
+        media, fps=fps, width=GRID_W, height=GRID_H, on_progress=on_progress
+    )
+    scores = change_scores(tiles, delta=delta)
+    marks = select_marks(scores, fps=fps, budget=budget, min_gap_s=min_gap_s)
+
+    result = with_marks(
+        payload,
+        marks,
+        {
+            "source": str(media),
+            "fps": fps,
+            "grid": [GRID_W, GRID_H],
+            "delta": delta,
+            "budget": budget,
+            "min_gap_s": min_gap_s,
+            "frames_sampled": len(tiles),
+        },
+    )
+    atomic_write_text(out, json.dumps(result))
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the CLI: add visual change marks to an existing transcript.
+
+    Returns:
+        A process exit code -- 0 on success.
+    """
+    import argparse
+
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+    ap = argparse.ArgumentParser(
+        description="Mark the moments a recording's picture changed most."
+    )
+    ap.add_argument("media", type=Path, help="the video the transcript indexes")
+    ap.add_argument("-t", "--transcript", type=Path, required=True)
+    ap.add_argument(
+        "-o",
+        "--out",
+        type=Path,
+        help="where to write transcript+marks; defaults to overwriting --transcript",
+    )
+    ap.add_argument("--fps", type=float, default=DEFAULT_FPS)
+    ap.add_argument("--delta", type=int, default=DEFAULT_DELTA)
+    ap.add_argument("--budget", type=int, default=DEFAULT_BUDGET)
+    ap.add_argument("--min-gap", type=float, default=DEFAULT_MIN_GAP_S)
+    args = ap.parse_args(argv)
+
+    tty = sys.stderr.isatty()
+    started = time.monotonic()
+
+    def show(done_s: float) -> None:
+        elapsed = time.monotonic() - started
+        speed = done_s / elapsed if elapsed > 0 else 0.0
+        print(
+            f"scanning {done_s:7.0f}s of video  {speed:4.1f}x",
+            end="\r" if tty else "\n",
+            file=sys.stderr,
+            flush=True,
+        )
+
+    result = mark_video(
+        args.media,
+        args.transcript,
+        args.out or args.transcript,
+        fps=args.fps,
+        delta=args.delta,
+        budget=args.budget,
+        min_gap_s=args.min_gap,
+        on_progress=show,
+    )
+    if tty:
+        print(file=sys.stderr)
+
+    marks: list[dict[str, Any]] = result["marks"]
+    scanned = result["marks_meta"]["frames_sampled"]
+    # A count and the span it covers, not a rate: "150 marks" alone reads as a
+    # lot or a little depending on a duration the reader has to go and find.
+    logger.info(
+        "%d marks over %d sampled frames in %.0fs",
+        len(marks),
+        scanned,
+        time.monotonic() - started,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deixis/media.py
+++ b/deixis/media.py
@@ -18,7 +18,9 @@ __all__ = [
     "FFmpegNotFound",
     "MediaError",
     "NoAudioStream",
+    "NoVideoStream",
     "extract_audio",
+    "extract_tile_grid",
     "needs_conversion",
     "probe",
 ]
@@ -32,6 +34,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import numpy as np
+from numpy.typing import NDArray
+
 
 class MediaError(RuntimeError):
     """ffmpeg could not do what we asked of this file."""
@@ -43,6 +48,10 @@ class FFmpegNotFound(MediaError):
 
 class NoAudioStream(MediaError):
     """The file opened, but carries no audio track to transcribe."""
+
+
+class NoVideoStream(MediaError):
+    """The file opened, but carries no picture to scan for changes."""
 
 
 @dataclass(frozen=True)
@@ -207,3 +216,137 @@ def extract_audio(
             f"-c:a pcm_s16le out.wav` by hand to see the full log."
         )
     return dest
+
+
+def has_video(media: Path) -> bool:
+    """Does `media` carry a picture at all?
+
+    Asked separately from probe() because that one describes the audio stream
+    and raises when there is none -- an audio-only file is a perfectly good
+    transcription input and a hopeless input to a change scan.
+    """
+    if not media.exists():
+        raise FileNotFoundError(media)
+    proc = subprocess.run(
+        [
+            _tool("ffprobe"),
+            "-v", "error",
+            "-select_streams", "v:0",
+            "-show_entries", "stream=codec_name",
+            "-print_format", "json",
+            str(media),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise MediaError(f"ffprobe could not read {media}: {proc.stderr.strip()}")
+    info: dict[str, Any] = json.loads(proc.stdout)
+    return bool(info.get("streams"))
+
+
+def extract_tile_grid(
+    media: Path,
+    *,
+    fps: float,
+    width: int,
+    height: int,
+    on_progress: Callable[[float], None] | None = None,
+) -> NDArray[np.uint8]:
+    """Sample `media`'s picture down to a grid of greyscale tile means.
+
+    ffmpeg does the decode, the downscale and the colour conversion; what
+    arrives here is `width * height` bytes per sampled frame and nothing else.
+    A 33-minute 2940x1912 recording at 1 fps and a 128x84 grid is 21 MB in
+    total, which is why the whole thing is returned as one array rather than
+    streamed -- and why the caller can afford to sweep parameters over it
+    without decoding twice.
+
+    The downscale is not merely a size reduction. Averaging each ~23x23-pixel
+    tile suppresses smooth low-contrast motion (a webcam tile) while preserving
+    the thin high-contrast edges of text and UI chrome, which is the behaviour
+    change detection wants and would otherwise have to implement.
+
+    Args:
+        media: The video to scan.
+        fps: Frames to sample per second of video.
+        width: Tiles across.
+        height: Tiles down.
+        on_progress: Called with seconds of video scanned so far. Derived from
+            the frame count rather than from ffmpeg's own `-progress`, which
+            would need stdout -- and stdout is carrying the pixels.
+
+    Returns:
+        An (N, height, width) uint8 array. N is 0 for a file with no frames.
+
+    Raises:
+        NoVideoStream: if `media` has no video stream.
+        MediaError: if ffmpeg exits non-zero.
+        ValueError: if `fps`, `width` or `height` is not positive.
+    """
+    if fps <= 0:
+        raise ValueError(f"fps must be positive, got {fps}")
+    if width <= 0 or height <= 0:
+        raise ValueError(f"grid must be positive, got {width}x{height}")
+    if not has_video(media):
+        raise NoVideoStream(
+            f"{media} has no video stream, so there are no frames to scan. "
+            f"A transcript of an audio-only file is complete on its own."
+        )
+
+    cmd = [
+        _tool("ffmpeg"),
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel", "error",
+        "-i", str(media),
+        # fps before scale: filtering at the source resolution and then
+        # discarding 35 of every 36 frames would do the expensive part 36 times
+        # over.
+        "-vf", f"fps={fps},scale={width}:{height},format=gray",
+        "-an",                 # the audio half of this file is already indexed
+        "-f", "rawvideo",
+        "-",
+    ]
+
+    frame_bytes = width * height
+    frames: list[NDArray[np.uint8]] = []
+    # stderr to a file and Popen as a context manager, for the same two reasons
+    # as extract_audio: a second pipe with no reader can deadlock, and an
+    # unclosed stdout leaks a descriptor until the collector happens to run.
+    with (
+        tempfile.TemporaryFile("w+") as errfile,
+        subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=errfile) as proc,
+    ):
+        assert proc.stdout is not None
+        while True:
+            # readexactly, spelled out: a pipe read returns what is available,
+            # not what was asked for, and a short read stitched onto the next
+            # one as if it were a whole frame would shear every frame after it.
+            buf = proc.stdout.read(frame_bytes)
+            if len(buf) < frame_bytes:
+                break
+            # No .copy(). frombuffer returns a read-only VIEW, which looks like
+            # it wants one -- but each read() hands back a fresh bytes object
+            # that the view keeps alive, so the frames do not alias each other,
+            # and np.stack below copies into a fresh writable array regardless.
+            # A per-frame copy here was written first and measured worthless: a
+            # mutant that removed it killed no test, because there was no defect
+            # for a test to catch.
+            frames.append(np.frombuffer(buf, dtype=np.uint8).reshape(height, width))
+            if on_progress:
+                on_progress(len(frames) / fps)
+        returncode = proc.wait()
+        errfile.seek(0)
+        stderr = errfile.read().strip()
+
+    if returncode != 0:
+        raise MediaError(
+            f"ffmpeg failed to scan {media} (exit {returncode}):\n{stderr}\n"
+            f"Try `ffmpeg -i {media} -vf fps={fps},scale={width}:{height} -f null -` "
+            f"by hand to see the full log."
+        )
+    if not frames:
+        return np.zeros((0, height, width), dtype=np.uint8)
+    return np.stack(frames)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,8 @@ likely to be useful.
 | [tooling-gaps.md](tooling-gaps.md) | **Start here.** The 16 practices and 3 tool tiers this project is built to, written out of an audit where five defects shipped past a fully green test suite. It is a general Python checklist, not a deixis one. |
 | [resume-gate-design.md](resume-gate-design.md) | How you test a resume that silently restarts, given that it produces byte-identical output. The design behind `scratch/resume_gate.py` and `tests/test_resume_gate.py`. |
 | [mutmut-triage.md](mutmut-triage.md) | Every mutant the test suite fails to kill, and why each one is accepted. Read this before adding a suppression. |
+| [visual-marks.md](visual-marks.md) | Three change detectors built, measured on a real recording, and thrown away — and the premise failure underneath all three. Why the shipped one has a budget and no threshold. |
+| [vlm-legibility.md](vlm-legibility.md) | Whether a small local VLM can read dense on-screen text. Ground truth written before the model ran; the answer is no, and the reason is hallucination rather than resolution. |
 
 ## The one idea they share
 
@@ -22,3 +24,8 @@ it also buys false confidence. Each document is an application of that:
 - **mutmut-triage** is the discipline turned on the tooling itself — a
   surviving mutant is either a missing test or an argued exception, never a
   number to drive down.
+- **visual-marks** is the same idea aimed at a feature rather than a test: three
+  detectors produced tidy, plausible summary statistics, and all three were
+  wrong. Looking at the frames is what showed it.
+- **vlm-legibility** is the ordering that makes a measurement honest — the
+  ground truth was written down before the model was allowed to speak.

--- a/docs/visual-marks.md
+++ b/docs/visual-marks.md
@@ -1,0 +1,199 @@
+# Visual marks: what was measured, and what it killed
+
+`deixis/frames.py` writes a bounded list of timestamps into the transcript at
+the moments the picture changed most. This is the record of how that design was
+arrived at, including the three approaches that were built, measured, and
+thrown away. Every number here came from a command; nothing is estimated.
+
+**The reference recording** throughout is
+`Screen Recording 2026-08-06 at 15.07.10.mov` — 2940x1912, 33 minutes, 60,065
+frames, a Microsoft Teams call in which a browser form, Outlook and Mission
+Control are all visited. It is a real working session, not a fixture. Sampled
+at 1 fps it is 1,997 frames.
+
+## The premise that was wrong
+
+The plan going in was: hash each sampled frame, mark the timestamps where the
+hash moved more than a threshold, and merge those into the transcript. It rests
+on an assumption nobody had checked — **that a screen recording is mostly
+static, so a change is a rare and therefore informative event.**
+
+On this recording the median one-second interval already moves 38 of 10,752
+tiles. The screen changes *most* seconds. Everything below follows from that one
+measurement.
+
+## Three detectors, three failures
+
+### 1. Perceptual hash — too coarse
+
+A 9x8 dHash over an ffmpeg pipe, which is what every off-the-shelf tool for
+this implements (`video-sampler`, `videostil`, `framewise`, `peepshow`,
+PySceneDetect's `detect-hash`, `imagehash`).
+
+```
+frames sampled : 1997  (fps=1)
+consecutive Hamming: mean=1.4 p50=0 p90=5 p99=13 max=46
+identical pairs    : 1185 / 1996
+
+thresh    kept   %kept  per-min
+     5     203   10.2%      6.1
+     8      74    3.7%      2.2
+```
+
+Those numbers look like a working detector. They are not. Extracting the frames
+at the marks and at the un-marks and **looking at them** shows:
+
+| Frame | Verdict | What actually changed |
+|---|---|---|
+| t=600, marked | true positive | Mission Control → Outlook inbox |
+| t=995, marked | weak true positive | text typed in a field, speaker tile switched |
+| **t=379, marked** | **false positive** | **nothing but the mouse pointer moving** |
+| **t=1195, unmarked** | **miss** | **a checkbox ticked, "Saved ✓" → "Saving…"** |
+| t=1812, unmarked | true negative | only the speaker-tile highlight |
+
+A 9x8 grid over a 2940x1912 frame gives 327x239-pixel cells. That resolves an
+application switch and nothing smaller — and because dHash compares *adjacent*
+cell brightness, near-equal cells on a white form flip bits from almost any
+perturbation, which is how a pointer trips it.
+
+This also lines up with the published literature: screen-content images are
+composed of text and graphics with different statistics from natural images,
+and hashing methods designed for natural images are documented as unsuitable
+for them.
+
+### 2. ffmpeg `mpdecimate` — too sensitive
+
+The industry-standard duplicate-frame dropper, 8x8-pixel block SAD with
+`hi`/`lo`/`frac` thresholds.
+
+```
+fps=1, mpdecimate (defaults)                  kept 1997 / 1997
+fps=1, mpdecimate=hi=1536:lo=640:frac=0.5     kept 1997 / 1997
+fps=1, crop out the webcam strip, defaults    kept 1592 / 1997
+```
+
+Zero frames dropped at any setting. Cropping the video-call tiles out removes
+20%, which proves they contribute — and leaves 80% still surviving, which
+proves they are not the whole story. `mpdecimate` exists to remove *encoder*
+duplicates; any real pixel motion defeats it.
+
+The two off-the-shelf options therefore fail in opposite directions and neither
+is tuneable into the middle, because both collapse a frame to a single decision
+with no notion of how large the change was or where.
+
+### 3. Tile grid with a learned activity mask — the right shape, wrong output
+
+Reimplementing SeeAction's change-region idea (per-pixel SSIM map → connected
+components → change-region bounding boxes; that paper samples screencasts at
+5 fps) on an ffmpeg+numpy pipe: decode to a 128x84 grid, diff tiles, suppress
+tiles that change chronically, mark when a large enough connected region moved.
+
+A sweep of 54 configurations — 3 grid sizes x 3 deltas x 2 mask levels x 3
+minimum cluster sizes — contains **no row** that marks t=1195 without also
+marking t=379:
+
+```
+    grid  delta   act  clust  marks   /min  masked%     379    1195
+  128x84     12  0.20      3   1659   49.8     0.0%    MARK    MARK
+   64x42     12  0.20      5    845   25.4     0.0%    MARK       -
+   32x21     12  0.20      3    574   17.2     0.0%       -       -
+```
+
+Two things fell out of that run, both of which contradicted the design:
+
+**The activity mask never engaged** (`masked% ≈ 0.0`), and the reason inverts
+the argument for having one. Per-row change frequency at delta=4:
+
+```
+row 20  y~455px  0.018  #      <- webcam tiles
+row 24  y~546px  0.026  ##     <- webcam tiles
+row 64  y~1456px 0.065  #####  <- browser content
+row 68  y~1547px 0.059  ####   <- browser content
+```
+
+**The webcam is not the noisy region.** Mean-pooling a ~23x23-pixel tile already
+destroys smooth low-contrast motion — a face, a room — while preserving the thin
+high-contrast edges that text and UI chrome are made of. The noisiest tiles are
+the *content*. The masking stage was designed to solve a problem the downscale
+had already solved, and it was deleted. (This is also, incidentally, what the
+screen-content hashing literature prescribes on purpose: hash where the
+gradients are.)
+
+**And no threshold can work**, because of the premise failure at the top: the
+score at t=379 (pointer only) is 75 and at t=1195 (checkbox) is 129, against a
+p90 of 1,092. Both are noise-floor events. There is no cut that separates them,
+and tuning against them was tuning against the wrong pair.
+
+## What shipped: rank under a budget
+
+Score every interval by changed-tile count, sort descending, take the top
+`budget` while keeping picks `min_gap_s` apart.
+
+```
+score distribution: p50=38 p90=1092 p99=2762 max=10235
+
+top-150, min gap 5s:
+gaps     : median 9s, p90 27s, max 79s
+coverage : 31 / 30 / 25 / 25 / 14 / 11 marks per five-minute bucket
+```
+
+Well spread, no clumping, no dead stretches. The **weakest** of the 150 picks
+(rank 150, score 492) was extracted and inspected by eye: a real form scroll
+from "drafting/writing · meeting notes" to "research · data analysis · deck
+building", with "Saving…" → "Saved ✓". The marginal pick is a real event, so
+the budget is if anything conservative.
+
+Why a budget beats a threshold, stated generally: **a threshold encodes an
+assumption about how often the content changes, and that assumption is a
+property of the recording, not of the detector.** A budget makes no such
+assumption. A static lecture yields 150 well-separated marks at the slide
+transitions; a frantic screen-share yields the 150 largest transitions in it.
+Same code, same bounded output, no per-video tuning.
+
+## Cost
+
+| Step | Reference recording (33 min) |
+|---|---|
+| ffmpeg decode + downscale to 128x84 @ 1 fps | **518s** |
+| decode + downscale to 9x8 @ 1 fps | 205s |
+| `-hwaccel videotoolbox`, 9x8 | 437s — **worse**; readback dominates |
+| tile diff + ranking, 1,997 frames | **33 ms** |
+
+Decode is the entire cost and the analysis is a rounding error on it — four
+orders of magnitude apart. If this ever needs to be faster the lever is the
+decode strategy (lower `fps`, keyframe-only extraction), never the arithmetic.
+Note that the finer grid costs 2.5x the decode of the coarse one: the scaler,
+not the pixel count coming out.
+
+## How the gate can fail
+
+Per practice #14 in [tooling-gaps.md](tooling-gaps.md), a check that cannot fail
+is not a check. Both halves of the failure space are pinned in
+`tests/test_frames.py`:
+
+- `test_static_video_yields_no_marks` — a video where nothing happens must
+  produce zero marks. Without it, a full budget on a real recording would prove
+  only that the budget was spent.
+- `test_marks_land_on_the_real_transitions` — a fixture cutting colour at t=4
+  and t=8 must be marked at exactly `[4.0, 8.0]`. A detector marking every
+  second would satisfy "both are marked", so the assertion is equality, not
+  membership.
+
+Twelve mutants were injected by hand against this suite. Ten were killed on the
+first pass; the three that survived each pointed at something real and are
+worth recording, because two of them were defects in the *tests* and one was a
+defect in the *code's justification*:
+
+| Mutant | Outcome |
+|---|---|
+| Remove the per-frame `.copy()` in `extract_tile_grid` | **Survived — the code was wrong, not the test.** Each `read()` returns a fresh `bytes` the view keeps alive, so there was no aliasing to defend against. The copy and its confident comment were deleted. |
+| `int16` → `uint8` subtraction (wrap) | Survived. The existing test used 250→10, which wraps to 16 — still over delta, so the count came out right for the wrong reason. Killed by 248→0, which wraps to exactly 8 and reads as *unchanged*: a screen going black would have scored zero. |
+| `kind="stable"` → `kind="quicksort"` | Survived. numpy's introsort is stable by accident on small inputs, so the three-element tie test pinned nothing. Killed at 305 elements, where the two sorts pick index 5 and index 152. |
+| Gap `>=` → `>`, and dropping the `1/fps` conversion | Survived initially — every gap test ran at 1 fps, where seconds and frame indices coincide. Killed by a 2 fps case and an exact-boundary case. |
+
+## What this does not do
+
+No frame is described. A mark says *something happened at t*, which is enough to
+navigate by and costs no tokens. Attaching a description to each mark is the
+next piece of work, and it is blocked on a measurement rather than on code — see
+[vlm-legibility.md](vlm-legibility.md).

--- a/docs/vlm-legibility.md
+++ b/docs/vlm-legibility.md
@@ -1,0 +1,107 @@
+# Can a small local VLM read a screen recording? Measured: no
+
+Describing the marked frames is the obvious next step after
+[visual-marks.md](visual-marks.md), and the plan was to do it locally: free,
+private, no API key, no uploads. Before building it, one question had to be
+answered, because everything downstream depends on it — **can a 2–4B model
+running on this machine actually read dense on-screen text?**
+
+Measured 2026-08-08 on the M2 MacBook Air (16 GB, fanless). Raw output,
+driver and hand-written ground truth are under `scratch/vlm/`.
+
+## Setup
+
+- Model: `mlx-community/gemma-4-e2b-it-4bit` (4-bit, 3.3 GB, already cached)
+- Runtime: `mlx-vlm` 0.6.10, in a venv separate from the project's
+- Prompt: *"Transcribe all text visible in this screenshot, then describe what
+  application is shown and what the user is doing. Be exhaustive about the
+  text."*, `max_tokens=400`
+- Decoding was **greedy** — `mlx_vlm.generate.ar.DEFAULT_TEMPERATURE` is `0.0`,
+  verified rather than assumed. Every reading below is the model's argmax, so
+  none of the errors are sampling noise.
+- Five frames from the reference recording. **Ground truth was hand-written
+  from the images before the model was run**, which is the only ordering that
+  does not bias it toward whatever the model happened to say.
+
+## Result
+
+| Frame | Content | Ground truth | Recalled | Hallucinated | Seconds |
+|---|---|---|---|---|---|
+| `DET_00600` | Outlook inbox, dense FR/EN list | 15 | **4** | 7 | 41.4 |
+| `DET_00995` | Web form, one question + answer | 13 | **8** | 2 | 19.9 |
+| `UNDET_01195` | Web form, radio row + 7 checkboxes | 15 | **10** | 2 | 21.6 |
+| `UNDET_01812` | Google Form, 6x5 radio matrix | 14 | **2** | 4 | 19.9 |
+| `TOPN_01129` | Web form, usage-frequency matrix | 13 | **9** | 3 | 18.1 |
+| **Total** | | **70** | **33 (47%)** | **18** | |
+
+Resolution is not the binding constraint. The same frame re-extracted at three
+widths:
+
+| Width | Recalled / 15 | Hallucinated |
+|---|---|---|
+| 700 px | 5 | ~5, plus heavy structural fabrication |
+| 1100 px | 4 | 7 |
+| 1600 px | 6 | 5 |
+
+Tripling the pixel count moved recall by one string. More pixels did let it read
+some genuinely small text it had missed, but it lost others and invented at the
+same rate.
+
+## Why the verdict is "no", and it is not the recall number
+
+47% recall on its own would be a starting point. The fabrications are the
+problem, because they are **fluent, correctly formatted, plausible UI text** —
+indistinguishable from a correct reading unless you have the image open beside
+it:
+
+> Image: `Your GPUs aren't the problem. Your storage …`
+> Model: `Your GPS aren't the problem. Your storage …`
+
+> Image: `Votre Kit AI Transformation est prêt — 8 livrat`
+> Model: `Votre Kit Air Transformation est prêt - 8 livré`
+
+Browser chrome present in every frame — identical pixels — came back as
+`OpenCLI Browser` on three frames, `OpenGL Browser` on one, and `OpenAI Browser`
+on another. Under greedy decoding, that spread means surrounding context alone
+flips what the model reads off the same pixels.
+
+An index built on this would silently contain a meeting where someone discussed
+GPS and an OpenAI browser. A wrong description is worse than no description,
+because a mark with no description is honestly empty and a mark with a
+fabricated one is not.
+
+Two structural failures matter as much as the string errors:
+
+- On the checkbox frame it transcribed all seven options and **omitted the
+  question above them** — `Verification, judgment & data safety`, with `Basic`
+  selected. The answer, dropped; the menu, kept.
+- On the 6x5 Google Form matrix it returned **none of the five column headers**
+  (`<2hr`, `>2 & <4hr`, …). A matrix without its column axis is not a lossy
+  record of the screen, it is an unusable one.
+
+And the reading pane of the Outlook frame — `Hello Moiz`, `Here my feedback`,
+`1 Entry point` — was recalled 0/4 at every resolution. That is the actual
+message content, the part a describer exists to capture.
+
+## Speed, also worse than assumed
+
+18–22 s per image at 400 tokens, steady state, after a 10.5 s model load. The
+planning estimate was ~5 s, extrapolated from a benchmark whose outputs were
+23–26 tokens; at 10.6 tok/s the 400-token budget is most of the difference.
+At 150 marks that is **45–55 minutes per 33 minutes of video**, not the
+~1:1 the plan assumed.
+
+## What this does not rule out
+
+- **A larger local model.** Only one was tested. `Qwen3-VL-4B-Instruct-4bit` is
+  a 2.5 GB download away and is the obvious next candidate; the project's own
+  README has long named Qwen2.5-VL-7B, which was never actually run.
+- **A terser prompt with a larger token budget.** The model spends its budget on
+  markdown scaffolding (`**Main Content Area (List/Table — Continued):**`) and
+  runs out mid-frame on dense screens. "Output only the text, no headings" with
+  more tokens is untested and cheap to try.
+- **A cloud VLM.** Not tested here at all.
+
+What it *does* rule out is shipping a describer on this model as it was
+configured, and it rules out temperature as the remedy — the run was already
+greedy, so the garbling is the model's best guess and not noise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,10 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "numba>=0.61",
+    # Direct since frames.py: it was already here transitively, but a module
+    # that imports it is a module that depends on it, and an indirect
+    # dependency can vanish under an upstream release with no warning.
+    "numpy>=2.0",
     "parakeet-mlx>=0.5.2",
     "pydantic>=2.13.4",
 ]

--- a/scratch/hash_probe.py
+++ b/scratch/hash_probe.py
@@ -1,0 +1,120 @@
+"""Measure change-point rates on a real video with a dHash over ffmpeg output.
+
+Decodes at a fixed fps, downscales to 9x8 greyscale in ffmpeg, computes a 64-bit
+difference hash per frame in numpy, and reports how many frames survive a
+Hamming-distance threshold against the last *kept* frame.
+
+Usage: python scratch/hash_probe.py <video> [--fps 1] [--thresholds 3,5,8,12]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+W, H = 9, 8
+FRAME_BYTES = W * H
+
+
+def decode_hashes(path: str, fps: float) -> tuple[np.ndarray, float]:
+    """Return (uint64 hashes, wall seconds) for every sampled frame."""
+    cmd = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-i",
+        path,
+        "-vf",
+        f"fps={fps},scale={W}:{H},format=gray",
+        "-f",
+        "rawvideo",
+        "-",
+    ]
+    start = time.monotonic()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    assert proc.stdout is not None
+    hashes: list[int] = []
+    try:
+        while True:
+            buf = proc.stdout.read(FRAME_BYTES)
+            if len(buf) < FRAME_BYTES:
+                break
+            f = np.frombuffer(buf, dtype=np.uint8).reshape(H, W)
+            bits = f[:, 1:] > f[:, :-1]
+            hashes.append(int.from_bytes(np.packbits(bits).tobytes(), "big"))
+    finally:
+        proc.stdout.close()
+        proc.wait()
+    return np.array(hashes, dtype=np.uint64), time.monotonic() - start
+
+
+def popcount(x: np.uint64) -> int:
+    return int(x).bit_count()
+
+
+def keep_count(hashes: np.ndarray, threshold: int) -> list[int]:
+    """Indices kept: first frame, then any frame >threshold from the last kept."""
+    if len(hashes) == 0:
+        return []
+    kept = [0]
+    last = hashes[0]
+    for i in range(1, len(hashes)):
+        if popcount(last ^ hashes[i]) > threshold:
+            kept.append(i)
+            last = hashes[i]
+    return kept
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("video")
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--thresholds", default="0,3,5,8,12,16")
+    ap.add_argument("--cache", help="npy file to read hashes from / write them to")
+    ap.add_argument("--dump", help="write kept indices per threshold as JSON here")
+    args = ap.parse_args()
+
+    if args.cache and Path(args.cache).exists():
+        hashes = np.load(args.cache)
+        secs = float("nan")
+    else:
+        hashes, secs = decode_hashes(args.video, args.fps)
+        if args.cache:
+            np.save(args.cache, hashes)
+    n = len(hashes)
+    print(f"frames sampled : {n}  (fps={args.fps})")
+    print(f"decode+hash    : {secs:.1f}s  ({n / secs:.0f} frames/s)")
+
+    if n > 1:
+        consec = np.array([popcount(hashes[i - 1] ^ hashes[i]) for i in range(1, n)])
+        pct = np.percentile(consec, [50, 75, 90, 99])
+        print(
+            "consecutive Hamming: "
+            f"mean={consec.mean():.1f} p50={pct[0]:.0f} p75={pct[1]:.0f} "
+            f"p90={pct[2]:.0f} p99={pct[3]:.0f} max={consec.max()}"
+        )
+        print(f"identical pairs    : {(consec == 0).sum()} / {n - 1}")
+
+    print()
+    print(f"{'thresh':>6} {'kept':>7} {'%kept':>7} {'per-min':>8}")
+    minutes = n / (args.fps * 60.0)
+    dumped: dict[str, list[int]] = {}
+    for t in (int(x) for x in args.thresholds.split(",")):
+        kept = keep_count(hashes, t)
+        dumped[str(t)] = kept
+        print(f"{t:>6} {len(kept):>7} {100 * len(kept) / n:>6.1f}% {len(kept) / minutes:>8.1f}")
+
+    if args.dump:
+        Path(args.dump).write_text(json.dumps({"fps": args.fps, "n": n, "kept": dumped}, indent=1))
+        print(f"\nwrote {args.dump}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/real_run.sh
+++ b/scratch/real_run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# End-to-end on a real screen recording: transcript, then visual marks.
+set -euo pipefail
+V="/Users/moiz/Desktop/Screen Recording 2026-08-06 at 15.07.10.mov"
+OUT=scratch/real_0806.json
+cd /Users/moiz/Documents/code/deixis
+echo "=== transcribe ==="
+uv run python -m deixis.transcribe "$V" -o "$OUT" --no-diarize
+echo "=== mark ==="
+uv run python -m deixis.frames "$V" -t "$OUT"
+echo "=== done ==="

--- a/scratch/tile_probe.py
+++ b/scratch/tile_probe.py
@@ -1,0 +1,202 @@
+"""Tile-grid change detection with a learned activity mask.
+
+Reimplements SeeAction's change-region idea (SSIM map -> connected regions) on an
+ffmpeg + numpy pipe: decode to a coarse greyscale grid, diff tiles, suppress tiles
+that change chronically (webcam tiles, clocks, spinners), and mark a frame when a
+large enough connected region of the remaining tiles changed.
+
+Decode once at a fine grid; coarser grids are derived by block-averaging, so a
+parameter sweep costs one decode.
+
+Usage:
+  python scratch/tile_probe.py <video> --cache scratch/tiles.npy          # decode
+  python scratch/tile_probe.py <video> --cache scratch/tiles.npy --sweep  # analyse
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+FINE_W, FINE_H = 128, 84  # ~23x23 px tiles on a 2940x1912 source
+
+
+def decode_tiles(path: str, fps: float, w: int, h: int) -> tuple[np.ndarray, float]:
+    """Decode the video to an (N, h, w) uint8 array of greyscale tile means."""
+    cmd = [
+        "ffmpeg",
+        "-v",
+        "error",
+        "-i",
+        path,
+        "-vf",
+        f"fps={fps},scale={w}:{h},format=gray",
+        "-f",
+        "rawvideo",
+        "-",
+    ]
+    n_bytes = w * h
+    start = time.monotonic()
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    assert proc.stdout is not None
+    frames: list[np.ndarray] = []
+    try:
+        while True:
+            buf = proc.stdout.read(n_bytes)
+            if len(buf) < n_bytes:
+                break
+            frames.append(np.frombuffer(buf, dtype=np.uint8).reshape(h, w))
+    finally:
+        proc.stdout.close()
+        proc.wait()
+    return np.stack(frames), time.monotonic() - start
+
+
+def coarsen(fine: np.ndarray, factor: int) -> np.ndarray:
+    """Block-average an (N, h, w) array down by an integer factor."""
+    if factor == 1:
+        return fine
+    n, h, w = fine.shape
+    h2, w2 = h // factor, w // factor
+    trimmed = fine[:, : h2 * factor, : w2 * factor].astype(np.uint16)
+    return trimmed.reshape(n, h2, factor, w2, factor).mean(axis=(2, 4)).astype(np.uint8)
+
+
+def largest_component(mask: np.ndarray) -> int:
+    """Size of the largest 4-connected True region in a 2-D boolean array."""
+    h, w = mask.shape
+    seen = np.zeros_like(mask)
+    best = 0
+    for sy, sx in np.argwhere(mask):
+        if seen[sy, sx]:
+            continue
+        size = 0
+        q = deque([(int(sy), int(sx))])
+        seen[sy, sx] = True
+        while q:
+            y, x = q.popleft()
+            size += 1
+            for ny, nx in ((y - 1, x), (y + 1, x), (y, x - 1), (y, x + 1)):
+                if 0 <= ny < h and 0 <= nx < w and mask[ny, nx] and not seen[ny, nx]:
+                    seen[ny, nx] = True
+                    q.append((ny, nx))
+        best = max(best, size)
+    return best
+
+
+Result = dict[str, Any]
+
+
+def analyse(
+    tiles: np.ndarray,
+    delta: int,
+    activity_max: float,
+    min_cluster: int,
+    mask_cap: float = 0.25,
+) -> Result:
+    """Mark frames whose unmasked changed tiles form a large enough region."""
+    d = np.abs(tiles[1:].astype(np.int16) - tiles[:-1].astype(np.int16))
+    changed = d > delta
+
+    activity = changed.mean(axis=0)
+    noisy = activity >= activity_max
+    noisy_frac = float(noisy.mean())
+    masked_off = noisy_frac <= mask_cap
+    usable = ~noisy if masked_off else np.ones_like(noisy)
+
+    marks: list[int] = []
+    sizes: list[int] = []
+    for i in range(changed.shape[0]):
+        region = changed[i] & usable
+        size = largest_component(region) if region.any() else 0
+        sizes.append(size)
+        if size >= min_cluster:
+            marks.append(i + 1)  # index into the frame array
+
+    return Result(
+        marks=marks,
+        n_frames=int(tiles.shape[0]),
+        cluster_sizes=sizes,
+        mask_applied=masked_off,
+        masked_tile_fraction=noisy_frac,
+        params={
+            "grid": [int(tiles.shape[2]), int(tiles.shape[1])],
+            "delta": delta,
+            "activity_max": activity_max,
+            "min_cluster": min_cluster,
+        },
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("video")
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--cache", required=True)
+    ap.add_argument("--sweep", action="store_true")
+    ap.add_argument("--dump", help="write marks for the best config as JSON")
+    ap.add_argument("--probe", default="379,1195", help="frame indices to report on")
+    args = ap.parse_args()
+
+    cache = Path(args.cache)
+    if cache.exists():
+        fine = np.load(cache)
+        print(f"loaded {cache} {fine.shape}")
+    else:
+        fine, secs = decode_tiles(args.video, args.fps, FINE_W, FINE_H)
+        np.save(cache, fine)
+        print(f"decoded {fine.shape} in {secs:.1f}s -> {cache}")
+
+    if not args.sweep:
+        return 0
+
+    probes = [int(x) for x in args.probe.split(",")]
+    minutes = fine.shape[0] / (args.fps * 60.0)
+    print(
+        f"\n{'grid':>8} {'delta':>6} {'act':>5} {'clust':>6} "
+        f"{'marks':>6} {'/min':>6} {'masked%':>8} " + " ".join(f"{p:>7}" for p in probes)
+    )
+
+    best: Result | None = None
+    t0 = time.perf_counter()
+    for factor, label in ((1, "128x84"), (2, "64x42"), (4, "32x21")):
+        tiles = coarsen(fine, factor)
+        for delta in (8, 12, 20):
+            for activity_max in (0.20, 0.35):
+                for min_cluster in (2, 3, 5):
+                    r = analyse(tiles, delta, activity_max, min_cluster)
+                    marks = set(r["marks"])
+                    hits = " ".join(f"{'MARK' if p in marks else '-':>7}" for p in probes)
+                    print(
+                        f"{label:>8} {delta:>6} {activity_max:>5.2f} {min_cluster:>6} "
+                        f"{len(r['marks']):>6} {len(r['marks']) / minutes:>6.1f} "
+                        f"{100 * r['masked_tile_fraction']:>7.1f}% {hits}"
+                    )
+                    # target: no mark at the cursor-only frame, a mark at the checkbox
+                    hit = probes[0] not in marks and probes[1] in marks
+                    if hit and (best is None or len(r["marks"]) < len(best["marks"])):
+                        best = r
+    print(f"\nsweep took {time.perf_counter() - t0:.1f}s")
+
+    if best is None:
+        print(f"NO CONFIG satisfies: no mark at {probes[0]} and a mark at {probes[1]}")
+        return 1
+    print(f"best: {best['params']}  marks={len(best['marks'])}")
+    if args.dump:
+        Path(args.dump).write_text(
+            json.dumps({k: v for k, v in best.items() if k != "cluster_sizes"}, indent=1)
+        )
+        print(f"wrote {args.dump}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/vlm/run.py
+++ b/scratch/vlm/run.py
@@ -1,0 +1,41 @@
+"""Run gemma-4-e2b-it-4bit over the frame set, one model load, timed per image."""
+
+import json
+import sys
+import time
+
+from mlx_vlm import generate, load
+from mlx_vlm.prompt_utils import apply_chat_template
+
+MODEL = "mlx-community/gemma-4-e2b-it-4bit"
+PROMPT = (
+    "Transcribe all text visible in this screenshot, then describe what "
+    "application is shown and what the user is doing. Be exhaustive about the text."
+)
+
+images = sys.argv[1:]
+
+t0 = time.perf_counter()
+model, processor = load(MODEL)
+config = model.config
+load_s = time.perf_counter() - t0
+print(f"model load: {load_s:.1f}s", file=sys.stderr)
+
+results = []
+for path in images:
+    formatted = apply_chat_template(processor, config, PROMPT, num_images=1)
+    t = time.perf_counter()
+    out = generate(
+        model, processor, formatted, [path], max_tokens=400, verbose=False
+    )
+    elapsed = time.perf_counter() - t
+    text = out.text if hasattr(out, "text") else str(out)
+    print(f"{path}: {elapsed:.1f}s", file=sys.stderr)
+    results.append({"image": path, "seconds": round(elapsed, 1), "output": text})
+
+json.dump(
+    {"model": MODEL, "load_seconds": round(load_s, 1), "results": results},
+    open("/Users/moiz/Documents/code/deixis/scratch/vlm/raw_output.json", "w"),
+    indent=2,
+    ensure_ascii=False,
+)

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -1,0 +1,456 @@
+"""frames.py: the scoring, the ranking, and the marks that come out.
+
+Two layers, deliberately separate. change_scores and select_marks are pure
+functions of an array and are tested on hand-built arrays where the right
+answer is arithmetic. mark_video and extract_tile_grid run real ffmpeg against
+videos ffmpeg synthesizes at test time, because a stubbed test of a subprocess
+wrapper asserts only that the stub was called.
+
+The negative controls are the point of this file. A change detector that marks
+everything and a change detector that marks nothing both LOOK like they work:
+one returns a full budget, the other returns a tidy short list. The tests that
+distinguish them are `test_static_video_yields_no_marks` (a video where nothing
+happens must produce zero marks -- if this passes while the others do too, the
+scoring is not merely present but discriminating) and
+`test_marks_land_on_the_real_transitions`, which builds a video whose cuts are
+at known seconds and demands the marks be there and not elsewhere.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from deixis import media
+from deixis.frames import (
+    DEFAULT_DELTA,
+    Mark,
+    change_scores,
+    main,
+    mark_video,
+    select_marks,
+    with_marks,
+)
+
+needs_ffmpeg = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not on PATH",
+)
+
+
+def _tiles(*frames: list[list[int]]) -> np.ndarray:
+    return np.array(frames, dtype=np.uint8)
+
+
+# --------------------------------------------------------------------------
+# change_scores
+# --------------------------------------------------------------------------
+
+
+def test_identical_frames_score_zero() -> None:
+    tiles = _tiles([[10, 10], [10, 10]], [[10, 10], [10, 10]])
+    assert change_scores(tiles).tolist() == [0]
+
+
+def test_score_counts_tiles_over_delta_not_frames() -> None:
+    # Three of four tiles move by 100, one stays put.
+    tiles = _tiles([[0, 0], [0, 0]], [[100, 100], [100, 0]])
+    assert change_scores(tiles, delta=8).tolist() == [3]
+
+
+def test_a_move_exactly_at_delta_does_not_count() -> None:
+    # The comparison is strictly greater, and a boundary that silently flips
+    # would shift every score by the number of tiles sitting on it.
+    tiles = _tiles([[0]], [[DEFAULT_DELTA]])
+    assert change_scores(tiles, delta=DEFAULT_DELTA).tolist() == [0]
+    tiles = _tiles([[0]], [[DEFAULT_DELTA + 1]])
+    assert change_scores(tiles, delta=DEFAULT_DELTA).tolist() == [1]
+
+
+def test_a_downward_move_counts_as_much_as_an_upward_one() -> None:
+    up = change_scores(_tiles([[10]], [[250]]))
+    down = change_scores(_tiles([[250]], [[10]]))
+    assert up.tolist() == down.tolist() == [1]
+
+
+def test_a_large_darkening_is_not_lost_to_an_unsigned_wrap() -> None:
+    """The subtraction must be done in a signed type.
+
+    248 -> 0 is the largest change a tile can nearly make. Under uint8 the
+    subtraction wraps to exactly 8, which is DEFAULT_DELTA, so the tile reads as
+    unchanged -- a screen going black would score zero. The gentler 250 -> 10
+    case above does NOT catch this: it wraps to 16, still over delta, so the
+    count comes out right for the wrong reason.
+    """
+    assert change_scores(_tiles([[248]], [[0]]), delta=DEFAULT_DELTA).tolist() == [1]
+
+
+def test_scores_are_one_shorter_than_frames() -> None:
+    tiles = np.zeros((5, 2, 2), dtype=np.uint8)
+    assert len(change_scores(tiles)) == 4
+
+
+def test_a_single_frame_has_no_intervals() -> None:
+    assert change_scores(np.zeros((1, 2, 2), dtype=np.uint8)).tolist() == []
+
+
+def test_no_frames_at_all_is_not_an_error() -> None:
+    assert change_scores(np.zeros((0, 2, 2), dtype=np.uint8)).tolist() == []
+
+
+def test_a_flat_array_is_rejected() -> None:
+    with pytest.raises(ValueError, match="expected an"):
+        change_scores(np.zeros((4, 4), dtype=np.uint8))
+
+
+def test_a_negative_delta_is_rejected() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        change_scores(np.zeros((2, 2, 2), dtype=np.uint8), delta=-1)
+
+
+# --------------------------------------------------------------------------
+# select_marks
+# --------------------------------------------------------------------------
+
+
+def _scores(*values: int) -> np.ndarray:
+    return np.array(values, dtype=np.int32)
+
+
+def test_the_budget_is_a_ceiling() -> None:
+    scores = _scores(*range(1, 21))
+    marks = select_marks(scores, fps=1.0, budget=5, min_gap_s=0.0)
+    assert len(marks) == 5
+
+
+def test_the_highest_scores_win() -> None:
+    scores = _scores(1, 9, 2, 8, 3)
+    marks = select_marks(scores, fps=1.0, budget=2, min_gap_s=0.0)
+    assert [m.score for m in marks] == [9, 8]
+
+
+def test_marks_come_back_in_time_order_not_ranked_order() -> None:
+    scores = _scores(5, 100, 50)
+    marks = select_marks(scores, fps=1.0, budget=3, min_gap_s=0.0)
+    assert [m.t for m in marks] == sorted(m.t for m in marks)
+    assert [m.t for m in marks] == [1.0, 2.0, 3.0]
+
+
+def test_the_timestamp_is_the_frame_after_the_change() -> None:
+    """Interval i sits between frames i and i+1; the change is visible at i+1.
+
+    Off by one here points every mark at the last frame before the thing
+    happened, which is the frame that does not show it.
+    """
+    marks = select_marks(_scores(0, 42), fps=1.0, budget=1, min_gap_s=0.0)
+    assert marks == [Mark(t=2.0, score=42)]
+
+
+def test_fps_scales_the_timestamps() -> None:
+    marks = select_marks(_scores(0, 42), fps=2.0, budget=1, min_gap_s=0.0)
+    assert marks == [Mark(t=1.0, score=42)]
+
+
+def test_the_gap_suppresses_a_neighbour_however_high_it_scores() -> None:
+    # Adjacent seconds, both enormous. The gap must keep only the larger.
+    marks = select_marks(_scores(100, 99, 0, 0, 0, 0, 50), fps=1.0, budget=3, min_gap_s=5.0)
+    assert [m.score for m in marks] == [100, 50]
+
+
+def test_without_a_gap_the_same_input_clusters() -> None:
+    """The negative control for the gap: it must actually change the answer.
+
+    A min_gap_s that did nothing would leave every other test here passing.
+    """
+    marks = select_marks(_scores(100, 99, 0, 0, 0, 0, 50), fps=1.0, budget=3, min_gap_s=0.0)
+    assert [m.score for m in marks] == [100, 99, 50]
+
+
+def test_a_gap_of_exactly_min_gap_is_wide_enough() -> None:
+    """The boundary is inclusive.
+
+    Two marks exactly min_gap_s apart are far enough apart by definition;
+    rejecting them costs one mark per boundary case for no reason a reader
+    could name.
+    """
+    scores = _scores(100, 0, 0, 0, 0, 90)
+    assert len(select_marks(scores, fps=1.0, budget=2, min_gap_s=5.0)) == 2
+    assert len(select_marks(scores, fps=1.0, budget=2, min_gap_s=5.001)) == 1
+
+
+def test_the_gap_is_measured_in_seconds_not_in_frames() -> None:
+    """min_gap_s must be converted through fps, not compared to an index.
+
+    At 2 fps these two intervals are 4 samples but only 2.0 seconds apart, so a
+    3-second gap must reject the second one. Comparing indices directly would
+    accept it -- and every other gap test here runs at 1 fps, where the two
+    readings coincide and the bug is invisible.
+    """
+    scores = _scores(100, 0, 0, 0, 90)
+    assert len(select_marks(scores, fps=2.0, budget=2, min_gap_s=3.0)) == 1
+    assert len(select_marks(scores, fps=2.0, budget=2, min_gap_s=1.5)) == 2
+
+
+def test_zero_scores_are_never_marked() -> None:
+    """A budget is a ceiling, not a quota.
+
+    Padding it with intervals where nothing moved would put marks on frames
+    identical to the one before them.
+    """
+    marks = select_marks(_scores(7, 0, 0, 0, 0), fps=1.0, budget=4, min_gap_s=0.0)
+    assert [m.score for m in marks] == [7]
+
+
+def test_all_zero_scores_yield_nothing() -> None:
+    assert select_marks(_scores(0, 0, 0), fps=1.0, budget=10, min_gap_s=0.0) == []
+
+
+def test_no_scores_yield_nothing() -> None:
+    assert select_marks(_scores(), fps=1.0, budget=10, min_gap_s=0.0) == []
+
+
+def test_ties_break_toward_the_earlier_frame() -> None:
+    marks = select_marks(_scores(5, 5, 5), fps=1.0, budget=1, min_gap_s=0.0)
+    assert marks == [Mark(t=1.0, score=5)]
+
+
+def test_ties_break_the_same_way_at_a_size_that_changes_the_sort() -> None:
+    """Determinism: two runs over one recording must not disagree.
+
+    numpy's default argsort is introsort, which is stable by accident on small
+    inputs -- the three-element case above passes under either kind, so it pins
+    nothing. Above the insertion-sort cutoff the two diverge: on this input the
+    stable sort takes index 5 and quicksort takes index 152, both scoring 3. A
+    real recording has hundreds of tied intervals, so this is the size that
+    matters, not the small one.
+    """
+    scores = np.concatenate([np.zeros(5, dtype=np.int32), np.full(300, 3, dtype=np.int32)])
+    marks = select_marks(scores, fps=1.0, budget=1, min_gap_s=0.0)
+    assert marks == [Mark(t=6.0, score=3)]
+
+
+def test_a_zero_budget_returns_nothing() -> None:
+    assert select_marks(_scores(9, 9), fps=1.0, budget=0, min_gap_s=0.0) == []
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"fps": 0.0}, "fps must be positive"),
+        ({"fps": -1.0}, "fps must be positive"),
+        ({"budget": -1}, "budget must be non-negative"),
+        ({"min_gap_s": -1.0}, "min_gap_s must be non-negative"),
+    ],
+)
+def test_nonsense_parameters_are_rejected(kwargs: dict[str, float], match: str) -> None:
+    args: dict[str, float] = {"fps": 1.0, "budget": 5, "min_gap_s": 0.0, **kwargs}
+    with pytest.raises(ValueError, match=match):
+        select_marks(_scores(1, 2, 3), **args)  # pyright: ignore[reportArgumentType]
+
+
+# --------------------------------------------------------------------------
+# with_marks
+# --------------------------------------------------------------------------
+
+
+def test_marks_are_added_beside_the_sentences() -> None:
+    payload = {"audio": "a.mov", "sentences": [{"start": 0.0}]}
+    out = with_marks(payload, [Mark(t=1.5, score=9)], {"budget": 1})
+    assert out["marks"] == [{"t": 1.5, "score": 9}]
+    assert out["sentences"] == payload["sentences"]
+
+
+def test_the_original_payload_is_left_alone() -> None:
+    payload: dict[str, object] = {"sentences": []}
+    with_marks(payload, [Mark(t=1.0, score=1)], {})
+    assert "marks" not in payload
+
+
+def test_the_parameters_travel_with_the_marks() -> None:
+    out = with_marks({}, [], {"budget": 150, "fps": 1.0})
+    assert out["marks_meta"] == {"budget": 150, "fps": 1.0}
+
+
+# --------------------------------------------------------------------------
+# The ffmpeg boundary and the end-to-end pass
+# --------------------------------------------------------------------------
+
+
+def _run_ffmpeg(*args: str) -> None:
+    subprocess.run(["ffmpeg", "-y", "-loglevel", "error", *args], check=True)
+
+
+@pytest.fixture
+def static_video(tmp_path: Path) -> Path:
+    """6 seconds of one unchanging colour."""
+    dest = tmp_path / "static.mp4"
+    _run_ffmpeg(
+        "-f", "lavfi", "-i", "color=c=0x202020:s=320x240:d=6:r=10",
+        "-pix_fmt", "yuv420p", str(dest),
+    )
+    return dest
+
+
+@pytest.fixture
+def cut_video(tmp_path: Path) -> Path:
+    """Three 4-second colours end to end, so the cuts are at t=4 and t=8.
+
+    Concatenated as encoded segments rather than drawn with a filter: the point
+    is a file whose transitions are at seconds a human can state in advance,
+    and the assertion below is against those two numbers.
+    """
+    parts: list[Path] = []
+    for i, colour in enumerate(("0x101010", "0xE0E0E0", "0x404040")):
+        part = tmp_path / f"part{i}.mp4"
+        _run_ffmpeg(
+            "-f", "lavfi", "-i", f"color=c={colour}:s=320x240:d=4:r=10",
+            "-pix_fmt", "yuv420p", str(part),
+        )
+        parts.append(part)
+    listing = tmp_path / "parts.txt"
+    listing.write_text("".join(f"file '{p}'\n" for p in parts))
+    dest = tmp_path / "cuts.mp4"
+    _run_ffmpeg("-f", "concat", "-safe", "0", "-i", str(listing), "-c", "copy", str(dest))
+    return dest
+
+
+@pytest.fixture
+def transcript(tmp_path: Path) -> Path:
+    dest = tmp_path / "t.json"
+    dest.write_text(json.dumps({"audio": "x.mov", "sentences": [{"start": 0.0, "end": 1.0}]}))
+    return dest
+
+
+@needs_ffmpeg
+def test_extract_tile_grid_returns_one_frame_per_sampled_second(static_video: Path) -> None:
+    tiles = media.extract_tile_grid(static_video, fps=1.0, width=8, height=6)
+    assert tiles.shape == (6, 6, 8)
+    assert tiles.dtype == np.uint8
+
+
+@needs_ffmpeg
+def test_extract_tile_grid_reports_progress(static_video: Path) -> None:
+    seen: list[float] = []
+    media.extract_tile_grid(static_video, fps=1.0, width=8, height=6, on_progress=seen.append)
+    assert seen == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+@needs_ffmpeg
+def test_frames_do_not_alias_one_another(cut_video: Path) -> None:
+    """Each sampled frame must carry its own pixels.
+
+    frombuffer returns a view, so a reader that reused one buffer across reads
+    would hand back N copies of the last frame -- every score zero, every
+    recording static, and no error anywhere to say so.
+    """
+    tiles = media.extract_tile_grid(cut_video, fps=1.0, width=8, height=6)
+    assert not np.array_equal(tiles[0], tiles[5])
+
+
+@needs_ffmpeg
+def test_an_audio_only_file_is_refused(tmp_path: Path) -> None:
+    wav = tmp_path / "a.wav"
+    _run_ffmpeg("-f", "lavfi", "-i", "sine=frequency=440:duration=2", str(wav))
+    with pytest.raises(media.NoVideoStream, match="no video stream"):
+        media.extract_tile_grid(wav, fps=1.0, width=8, height=6)
+
+
+@needs_ffmpeg
+def test_a_missing_file_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        media.extract_tile_grid(tmp_path / "nope.mov", fps=1.0, width=8, height=6)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"fps": 0.0}, "fps must be positive"),
+        ({"width": 0}, "grid must be positive"),
+        ({"height": -1}, "grid must be positive"),
+    ],
+)
+@needs_ffmpeg
+def test_extract_tile_grid_rejects_nonsense(
+    static_video: Path, kwargs: dict[str, float], match: str
+) -> None:
+    args: dict[str, float] = {"fps": 1.0, "width": 8, "height": 6, **kwargs}
+    with pytest.raises(ValueError, match=match):
+        media.extract_tile_grid(static_video, **args)  # pyright: ignore[reportArgumentType]
+
+
+@needs_ffmpeg
+def test_static_video_yields_no_marks(static_video: Path, transcript: Path, tmp_path: Path) -> None:
+    """THE NEGATIVE CONTROL.
+
+    A recording where nothing happens must produce nothing. If this fails, a
+    full budget of marks on a real recording proves only that the budget was
+    spent.
+    """
+    out = tmp_path / "out.json"
+    result = mark_video(static_video, transcript, out, fps=1.0, budget=50, min_gap_s=0.0)
+    assert result["marks"] == []
+
+
+@needs_ffmpeg
+def test_marks_land_on_the_real_transitions(
+    cut_video: Path, transcript: Path, tmp_path: Path
+) -> None:
+    """THE POSITIVE CONTROL, with the answer known before the run.
+
+    The fixture cuts colour at t=4 and t=8 and nowhere else. Both must be
+    marked, and -- because a detector that marks every second would also
+    satisfy "both are marked" -- nothing else may be.
+    """
+    out = tmp_path / "out.json"
+    result = mark_video(cut_video, transcript, out, fps=1.0, budget=50, min_gap_s=0.0)
+    marked = sorted(m["t"] for m in result["marks"])
+    assert marked == [4.0, 8.0]
+
+
+@needs_ffmpeg
+def test_the_transcript_survives_the_pass(
+    cut_video: Path, transcript: Path, tmp_path: Path
+) -> None:
+    out = tmp_path / "out.json"
+    result = mark_video(cut_video, transcript, out, fps=1.0)
+    assert result["sentences"] == [{"start": 0.0, "end": 1.0}]
+    assert result["audio"] == "x.mov"
+    assert json.loads(out.read_text()) == result
+
+
+@needs_ffmpeg
+def test_the_meta_records_what_was_run(cut_video: Path, transcript: Path, tmp_path: Path) -> None:
+    out = tmp_path / "out.json"
+    result = mark_video(cut_video, transcript, out, fps=1.0, budget=7, min_gap_s=2.0)
+    meta = result["marks_meta"]
+    assert meta["budget"] == 7
+    assert meta["min_gap_s"] == 2.0
+    assert meta["frames_sampled"] == 12
+
+
+@needs_ffmpeg
+def test_a_missing_transcript_is_refused(cut_video: Path, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        mark_video(cut_video, tmp_path / "nope.json", tmp_path / "out.json")
+
+
+@needs_ffmpeg
+def test_the_cli_writes_marks_in_place(cut_video: Path, transcript: Path) -> None:
+    assert main([str(cut_video), "-t", str(transcript), "--budget", "50", "--min-gap", "0"]) == 0
+    written = json.loads(transcript.read_text())
+    assert sorted(m["t"] for m in written["marks"]) == [4.0, 8.0]
+
+
+@needs_ffmpeg
+def test_the_cli_honours_an_explicit_output(
+    cut_video: Path, transcript: Path, tmp_path: Path
+) -> None:
+    out = tmp_path / "elsewhere.json"
+    assert main([str(cut_video), "-t", str(transcript), "-o", str(out)]) == 0
+    assert "marks" in json.loads(out.read_text())
+    assert "marks" not in json.loads(transcript.read_text())

--- a/uv.lock
+++ b/uv.lock
@@ -507,6 +507,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numba" },
+    { name = "numpy" },
     { name = "parakeet-mlx" },
     { name = "pydantic" },
 ]
@@ -529,6 +530,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "numba", specifier = ">=0.61" },
+    { name = "numpy", specifier = ">=2.0" },
     { name = "parakeet-mlx", specifier = ">=0.5.2" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "senko", marker = "extra == 'diarize'", specifier = ">=0.1.0,<0.2" },


### PR DESCRIPTION
Adds `deixis/frames.py`: a second pass over the video that writes a bounded list of timestamps into the transcript at the moments the picture moved most. No frame is described — a mark says *something happened at t*, which is enough to navigate by and costs no tokens.

```bash
uv run python -m deixis.frames recording.mov -t transcript.json
```

## Why a budget and not a threshold

Three threshold-based detectors were built and measured on a real 33-minute 2940×1912 screen recording before this one. All three failed:

| Detector | Result |
|---|---|
| 9×8 dHash (what every off-the-shelf tool implements) | Fires on **pointer movement alone** at t=379; **misses a ticked checkbox** at t=1195. 327×239 px cells resolve nothing smaller than a window switch. |
| ffmpeg `mpdecimate` (the standard duplicate dropper) | Keeps **1997 of 1997** frames at every setting tried. Cropping the webcam strip removes 20% and leaves 80%. |
| Tile grid + learned activity mask | **54 configurations**, not one marks t=1195 without also marking t=379. |

The premise underneath all three is what actually failed: during an active working session **the screen changes most seconds** — the median one-second interval already moves 38 tiles. "The screen changed" is not a rare event, so it cannot be an index.

Ranking under a fixed budget makes no assumption about how often content changes. A static lecture yields marks at the slide transitions; a frantic screen-share yields its largest transitions. Same code, bounded output, no per-video tuning.

The activity mask designed to suppress webcam tiles was **deleted after measurement**: mean-pooling to a 128×84 grid already does it. The busiest rows are the browser content (0.06), not the video-call tiles (0.006–0.026).

## Verified end to end

Real run on the reference recording, transcript then marks:

```
150 marks over 1997 sampled frames in 171s   (11.7x realtime)
gaps      : median 9s, p90 27s, max 79s, min 5s
coverage  : 32 / 31 / 24 / 26 / 14 / 10 / 13 per five-minute bucket
```

The top-scoring mark lands on the sentence *"This is why if I go back **here** if I start **here**"* — the deictic case the project is named for.

## Tests

45 new tests. The two that make the gate able to fail:

- `test_static_video_yields_no_marks` — a video where nothing happens must yield zero. Without it, a full budget on a real recording proves only that the budget was spent.
- `test_marks_land_on_the_real_transitions` — a fixture cutting colour at t=4 and t=8 must yield exactly `[4.0, 8.0]`. Equality, not membership, so a detector marking every second fails.

Twelve mutants injected by hand; the three survivors each found something real, including one defect in the **code's justification**: the per-frame `.copy()` in `extract_tile_grid` defended against an aliasing that cannot happen, so it and its confident comment are gone. The other two were defects in the tests — a `uint8` wrap test that passed for the wrong reason, and gap tests that all ran at 1 fps where seconds and frame indices coincide.

`just check` green: pyright strict clean on package and tests, ruff clean, 176 passed.

## Docs

- `docs/visual-marks.md` — the three failed detectors, with the frames and numbers.
- `docs/vlm-legibility.md` — the measurement blocking the description pass. `gemma-4-e2b-it-4bit` recovered 33 of 70 hand-written ground-truth strings across five real frames while fabricating 18, at 18–22 s/image. Ground truth was written **before** the model ran.

Two README claims are corrected rather than left standing, and the roadmap's planned eval set is dropped with its reason: it existed to calibrate a threshold, and a budget has none.