### PR TITLE
feat: retrieve the frame at a timestamp, and measure what it is worth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             exit 1
           fi
           passed=$(grep -oE '[0-9]+ passed' /tmp/summary | grep -oE '^[0-9]+')
-          if [ "${passed:-0}" -lt 176 ]; then
-            echo "::error::fast lane is ${passed:-no} passed, floor is 176 -- the suite shrank"
+          if [ "${passed:-0}" -lt 182 ]; then
+            echo "::error::fast lane is ${passed:-no} passed, floor is 182 -- the suite shrank"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ in the meeting and, as text, it is worthless. The referent was on screen.
 | | |
 |---|---|
 | **Transcript half** | working — ingestion, chunked ASR, resume, optional speaker labels |
-| **Visual marks** | working — the moments the picture changed, written into the transcript. No description attached |
+| **Visual marks** | working — the moments the picture changed, written into the transcript. No description attached. [Measured](docs/do-marks-help.md) to be worth little on their own |
+| **Frame retrieval** | working — `media.extract_frame(video, t, dest)`. This is what actually makes a recording answerable: 5/16 → 16/16 on a blind-graded question set |
 | **Frame description** | **not built**, and now blocked on a *measured* finding rather than an unmeasured one. See [Roadmap](#roadmap) |
 
 So today deixis is a resumable, observable transcriber that also tells you
@@ -174,6 +175,7 @@ can fail. That cost is the point — see [docs/tooling-gaps.md](docs/tooling-gap
 | [docs/resume-gate-design.md](docs/resume-gate-design.md) | how you test a resume that silently restarts, given it produces byte-identical output |
 | [docs/mutmut-triage.md](docs/mutmut-triage.md) | every surviving mutant and why it is accepted |
 | [docs/visual-marks.md](docs/visual-marks.md) | the three change detectors that were built and measured before this one, and why each failed |
+| [docs/do-marks-help.md](docs/do-marks-help.md) | do the marks actually help an agent? Three arms, blind-graded: 5/16 → 7/16 → 16/16 |
 | [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Measured: not this one |
 
 ---

--- a/deixis/media.py
+++ b/deixis/media.py
@@ -20,7 +20,9 @@ __all__ = [
     "NoAudioStream",
     "NoVideoStream",
     "extract_audio",
+    "extract_frame",
     "extract_tile_grid",
+    "has_video",
     "needs_conversion",
     "probe",
 ]
@@ -244,6 +246,73 @@ def has_video(media: Path) -> bool:
         raise MediaError(f"ffprobe could not read {media}: {proc.stderr.strip()}")
     info: dict[str, Any] = json.loads(proc.stdout)
     return bool(info.get("streams"))
+
+
+def extract_frame(media: Path, t: float, dest: Path, *, width: int | None = None) -> Path:
+    """Write the frame at `t` seconds of `media` to `dest`.
+
+    The other half of the bargain the whole design rests on: the transcript and
+    its marks are an index, and an index is only worth having if you can open
+    what it points at. Nothing is precomputed and no frames are cached -- the
+    video is already on disk and seeking into it is cheap, so a frame costs
+    nothing until somebody asks for one.
+
+    Args:
+        media: The video to seek into.
+        t: Seconds from the start. Must be within the file.
+        dest: Where to write. The suffix picks the format; `.jpg` is the one a
+            vision model wants.
+        width: Scale to this many pixels wide, preserving aspect. None keeps
+            the source resolution -- 2940x1912 is ~776 KB as a JPEG, which is
+            over what most vision APIs want per image.
+
+    Returns:
+        `dest`.
+
+    Raises:
+        NoVideoStream: if `media` has no picture.
+        MediaError: if ffmpeg fails, or succeeds without writing a frame.
+        ValueError: if `t` is negative or `width` is not positive.
+    """
+    if t < 0:
+        raise ValueError(f"t must be non-negative, got {t}")
+    if width is not None and width <= 0:
+        raise ValueError(f"width must be positive, got {width}")
+    if not has_video(media):
+        raise NoVideoStream(f"{media} has no video stream, so there is no frame at {t}s.")
+
+    cmd = [
+        _tool("ffmpeg"),
+        "-nostdin",
+        "-hide_banner",
+        "-loglevel", "error",
+        "-y",
+        # -ss BEFORE -i is the fast form: ffmpeg seeks the container instead of
+        # decoding from zero, which on a 33-minute file is the difference
+        # between milliseconds and half a minute. It has been frame-accurate
+        # since 2.1 -- the old "input seeking is approximate" advice predates
+        # that and would cost a full decode to avoid a problem that is gone.
+        "-ss", str(t),
+        "-i", str(media),
+        "-frames:v", "1",
+        "-q:v", "2",
+    ]
+    if width is not None:
+        cmd += ["-vf", f"scale={width}:-2"]  # -2, not -1: keeps the height even
+    cmd.append(str(dest))
+
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    # Both conditions, not just the exit code. A seek past the end of the file
+    # fails deep in the encoder -- observed exit 234 with "Nothing was written
+    # into output file" buried under nine lines of thread teardown -- and the
+    # useful diagnosis is the missing file, not that log.
+    if proc.returncode != 0 or not dest.exists():
+        raise MediaError(
+            f"ffmpeg could not extract a frame at {t}s from {media} "
+            f"(exit {proc.returncode}):\n{proc.stderr.strip()}\n"
+            f"The usual cause is a timestamp past the end of the recording."
+        )
+    return dest
 
 
 def extract_tile_grid(

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ likely to be useful.
 | [resume-gate-design.md](resume-gate-design.md) | How you test a resume that silently restarts, given that it produces byte-identical output. The design behind `scratch/resume_gate.py` and `tests/test_resume_gate.py`. |
 | [mutmut-triage.md](mutmut-triage.md) | Every mutant the test suite fails to kill, and why each one is accepted. Read this before adding a suppression. |
 | [visual-marks.md](visual-marks.md) | Three change detectors built, measured on a real recording, and thrown away — and the premise failure underneath all three. Why the shipped one has a budget and no threshold. |
+| [do-marks-help.md](do-marks-help.md) | A three-arm, blind-graded measurement of whether the marks actually improve a downstream agent. Transcript only 5/16, plus marks 7/16, plus frame access 16/16 — and the marks turn out to point at the least readable instant in their neighbourhood. |
 | [vlm-legibility.md](vlm-legibility.md) | Whether a small local VLM can read dense on-screen text. Ground truth written before the model ran; the answer is no, and the reason is hallucination rather than resolution. |
 
 ## The one idea they share

--- a/docs/do-marks-help.md
+++ b/docs/do-marks-help.md
@@ -1,0 +1,135 @@
+# Do the marks help an agent? A three-arm measurement
+
+[visual-marks.md](visual-marks.md) establishes that the marks land on the
+biggest visual changes. That is a claim about the detector. It is not the claim
+that matters, which is: **does a downstream agent answer better because the
+marks are there?** This is the measurement of that, and the answer is mostly no
+— with one specific, fixable reason why.
+
+## Method
+
+**Questions, chosen by rule rather than by taste.** Every sentence in the
+reference recording's transcript containing two or more demonstratives ("this",
+"here", "that", "these", "there") and 40–200 characters long: 45 candidates.
+Then the densest one from each three-minute bucket: ten. Two were dropped as
+non-visual (a scheduling remark, a vague aside), leaving **eight questions**
+spanning 05:16 to 30:11. These are exactly the sentences the project is named
+for — the ones that are worthless as text.
+
+**Answer key** written by extracting the frame at each timestamp and reading it,
+**before any arm was run**. Two points per question: one for naming the right
+application and page, one for reproducing a specific item from it.
+
+**Three arms**, each a separate agent with no shared context and no access to
+the key:
+
+| Arm | Given |
+|---|---|
+| A | the transcript, with `marks` stripped out |
+| B | the transcript **+ marks** |
+| C | the transcript + marks + the ability to extract and view any frame |
+
+**Grading was blind.** The three answer sets were stripped of self-identifying
+sections, shuffled under a seed, relabelled X/Y/Z, and handed to a fourth agent
+with the key and the rubric. The mapping was withheld until after grading.
+
+## Result
+
+| Arm | Score | Correct | Honest "cannot tell" | Fabrications |
+|---|---|---|---|---|
+| A — transcript only | 5 / 16 | 4 | 3 | 1 |
+| B — transcript + marks | 7 / 16 | 5 | 2 | 1 |
+| **C — + frame access** | **16 / 16** | **8** | **0** | **0** |
+
+**Marks alone bought two points out of sixteen on eight questions.** That is
+inside the noise of an n=8 set, and both A and B fabricated on the same
+question — the marks did not prevent the one confident wrong answer either arm
+gave.
+
+**Frame access is the whole effect.** Arm C answered every question correctly
+with no hedging and no fabrication, from 15 extracted frames.
+
+The blind grader, not knowing which arm was which, described the difference in
+kind rather than degree: arm C "is answering a different question… it reports
+what it looked at *and rejected*, which is the behaviour of something reading
+pixels rather than reconstructing from words," while A and B "fail in the same
+place and the same way: wherever the speaker's words describe the artefact he is
+*talking about* rather than the one he is *showing*, they follow the words."
+
+Arm B's own verdict, written before it knew its score:
+
+> A mark is a timestamp and a tile count. There is no description, no text, no
+> thumbnail. Every application name, page name, heading, label, and value in the
+> eight answers above came from the spoken words. […] Not a single "cannot tell"
+> became a nameable answer because of them.
+
+## Two findings that change the design
+
+### 1. The marks are worse than random at pointing you at the right moment
+
+For each of the eight questions, how far is the nearest mark?
+
+```
+change-ranked marks : median 8.9s from the question    1/8 within 5s
+150 random seconds  : median 4.7s (mean over 2000 draws)
+random beats or ties the change-ranked marks in 1919/2000 draws  (p = 0.96)
+```
+
+This is the ICCV 2025 result — that random sampling matches or beats most
+sophisticated frame selection — reproducing exactly, on this recording, for this
+task. It was a known risk and it was not checked until after the feature shipped.
+
+The reason is structural, and it is not a bug in the detector: **a large visual
+change is a transition, and explanation happens on the plateau after it.** The
+marks correctly identify the boundaries; the questions are about the middles.
+
+Used the way the boundaries suggest — "seek to the last mark at or before t" —
+the marks do beat random, but thinly:
+
+```
+frame at the preceding mark shows the same screen as t:
+  change-ranked  97.3% on the eight questions, 94.8% across all 1996 seconds
+  random         92.6%                          92.5%
+```
+
+### 2. A mark points at the least readable frame in its neighbourhood
+
+Arm C reported that mark frames kept landing on mid-load skeletons and
+mid-animation window switches — the highest-scoring mark it sampled (score
+10,235) turned out to be a macOS Mission Control animation: maximum pixel churn,
+zero content. Measuring that claim across all 150 marks:
+
+```
+local instability (tiles differing from the neighbouring frames)
+  at a mark            mean 0.099
+  midway between marks mean 0.020      <- 5.0x more stable
+  a random second      mean 0.028
+
+34 of 150 marks (23%) sit in the top 5% most unstable seconds of the recording
+```
+
+**The marks systematically point at the worst instants to look at.** They are
+defined as the moments of maximum change, and a moment of maximum change is by
+construction a moment when the screen is mid-way between two states.
+
+## What follows
+
+The fix is small and falls out of the two findings together: a mark is a
+**segment boundary**, so the frame worth extracting is the **midpoint between
+consecutive marks**, not the mark itself. That is a few lines on top of what
+exists, and it converts a list of transitions into a list of stable screens —
+which is what a describer or a retriever actually wants.
+
+Two things this measurement does not establish:
+
+- **n = 8.** The point estimates are directional, not precise. The 5/16 → 16/16
+  gap is far too large to be noise; the 5/16 → 7/16 gap is well within it.
+- It tests **point-in-time questions** ("what was on screen at t"), because the
+  question set gives timestamps. Arm C noted the marks would earn their keep on
+  a different shape — "walk me through what he demoed" — where segment
+  boundaries are the answer rather than a means to it. That is untested.
+
+The headline stands on its own, though: **for making a recording answerable, the
+frames are the product and the marks are scaffolding.** Adding `extract_frame`
+moved the score from 5/16 to 16/16. Everything else here is about pointing it at
+better frames.

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -285,6 +285,30 @@ def _run_ffmpeg(*args: str) -> None:
     subprocess.run(["ffmpeg", "-y", "-loglevel", "error", *args], check=True)
 
 
+def _mean_grey(image: Path) -> float:
+    """Average brightness of a still image, read back through ffmpeg.
+
+    Not extract_tile_grid: that runs an `fps` filter, and a still has no
+    duration for it to sample, so it returns zero frames. Found by running it.
+    """
+    out = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(image),
+         "-vf", "scale=8:8,format=gray", "-f", "rawvideo", "-"],
+        capture_output=True, check=True,
+    ).stdout
+    return float(np.frombuffer(out, dtype=np.uint8).mean())
+
+
+def _dimensions(image: Path) -> tuple[int, int]:
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", str(image)],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    w, h = out.split("x")
+    return int(w), int(h)
+
+
 @pytest.fixture
 def static_video(tmp_path: Path) -> Path:
     """6 seconds of one unchanging colour."""
@@ -381,6 +405,62 @@ def test_extract_tile_grid_rejects_nonsense(
     args: dict[str, float] = {"fps": 1.0, "width": 8, "height": 6, **kwargs}
     with pytest.raises(ValueError, match=match):
         media.extract_tile_grid(static_video, **args)  # pyright: ignore[reportArgumentType]
+
+
+@needs_ffmpeg
+def test_extract_frame_writes_the_frame_at_that_second(cut_video: Path, tmp_path: Path) -> None:
+    """The index is only worth having if what it points at can be opened.
+
+    The fixture is black for 0-4s and near-white for 4-8s, so a seek that
+    landed in the wrong segment shows up as a brightness the assertion below
+    can catch -- where "a file was written" could not.
+    """
+    early = media.extract_frame(cut_video, 1.0, tmp_path / "early.png")
+    late = media.extract_frame(cut_video, 6.0, tmp_path / "late.png")
+    assert _mean_grey(early) < 64 < 192 < _mean_grey(late)
+
+
+@needs_ffmpeg
+def test_extract_frame_can_scale(cut_video: Path, tmp_path: Path) -> None:
+    dest = media.extract_frame(cut_video, 1.0, tmp_path / "small.png", width=64)
+    assert _dimensions(dest) == (64, 48)  # the fixture is 320x240
+
+
+@needs_ffmpeg
+def test_a_timestamp_past_the_end_is_an_error_not_an_empty_file(
+    cut_video: Path, tmp_path: Path
+) -> None:
+    """A seek past the end fails deep in the encoder and writes nothing.
+
+    Without the `dest.exists()` half of the check, a caller would get a path
+    back and discover the absence later, somewhere with no context.
+    """
+    dest = tmp_path / "nope.jpg"
+    with pytest.raises(media.MediaError, match="past the end"):
+        media.extract_frame(cut_video, 9999.0, dest)
+    assert not dest.exists()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [({"t": -1.0}, "t must be non-negative"), ({"width": 0}, "width must be positive")],
+)
+@needs_ffmpeg
+def test_extract_frame_rejects_nonsense(
+    cut_video: Path, tmp_path: Path, kwargs: dict[str, float], match: str
+) -> None:
+    args: dict[str, float] = {"t": 1.0, **kwargs}
+    t = args.pop("t")
+    with pytest.raises(ValueError, match=match):
+        media.extract_frame(cut_video, t, tmp_path / "x.jpg", **args)  # pyright: ignore[reportArgumentType]
+
+
+@needs_ffmpeg
+def test_extract_frame_refuses_an_audio_only_file(tmp_path: Path) -> None:
+    wav = tmp_path / "a.wav"
+    _run_ffmpeg("-f", "lavfi", "-i", "sine=frequency=440:duration=2", str(wav))
+    with pytest.raises(media.NoVideoStream):
+        media.extract_frame(wav, 1.0, tmp_path / "x.jpg")
 
 
 @needs_ffmpeg


### PR DESCRIPTION
Adds `media.extract_frame(video, t, dest, width=...)` — the other half of the bargain the design rests on. Then measures whether any of the visual half actually helps.

## The measurement

Eight questions drawn **by rule** from the transcript's deictic sentences (≥2 demonstratives, 40–200 chars, densest per three-minute bucket) — the sentences this project is named for, the ones that are worthless as text. Answer key written from the frames **before any arm ran**. Three agents, no shared context, no access to the key. **Grading was blind**: answer sets stripped of self-identifying sections, shuffled under a seed, relabelled X/Y/Z, handed to a fourth agent.

| Arm | Score | Correct | Honest "cannot tell" | Fabrications |
|---|---|---|---|---|
| transcript only | 5 / 16 | 4 | 3 | 1 |
| transcript + marks | 7 / 16 | 5 | 2 | 1 |
| **+ frame access** | **16 / 16** | **8** | **0** | **0** |

**Marks alone bought 2 points of 16 on n=8** — inside the noise, and they did not prevent the one fabrication either text-only arm produced. **Frame access is the entire effect.**

The marks arm, before it knew its score: *"Not a single 'cannot tell' became a nameable answer because of them."*

## Two findings that redirect the next work

**1. The marks are worse than random at pointing at the right moment.**

```
change-ranked marks : median 8.9s from the question
150 random seconds  : median 4.7s
random beats or ties in 1919/2000 draws  (p = 0.96)
```

This is the ICCV 2025 random-baseline result reproducing on our own data. It was flagged in the original planning notes as *"the single most likely way to waste a week here"* and it was not run until after the feature shipped. Recorded rather than buried.

The cause is structural, not a bug: a large change is a *transition*, and explanation happens on the *plateau* after it. Used as segment starts instead, the marks do win — thinly (94.8% vs 92.5% same-screen).

**2. A mark points at the least readable frame in its neighbourhood.**

```
local instability   at a mark            0.099
                    midway between       0.020    <- 5.0x more stable
23% of marks sit in the top 5% most unstable seconds of the recording
```

Arm C kept hitting mid-load skeletons and mid-animation window switches; the single highest-scoring mark in the recording (10,235) is a macOS Mission Control animation — maximum pixel churn, zero content.

Both point at the same small fix, **filed rather than done here** (`deixis-…`): a mark is a segment *boundary*, so the frame worth extracting is the *midpoint* between consecutive marks.

## Honest limits

n=8. The 5/16 → 16/16 gap is far too large to be noise; the 5/16 → 7/16 gap is well within it. And the question set gives timestamps, so it tests point-in-time questions only — arm C noted the marks would plausibly earn their keep on "walk me through what he demoed", which is untested.

## Tests

Six new tests for `extract_frame`, including the out-of-range seek that ffmpeg fails on deep in the encoder while writing nothing — the check is `returncode != 0 or not dest.exists()`, because the exit code alone arrives buried under nine lines of thread teardown.

Two of my tests were wrong on first run and were fixed by running them: `extract_tile_grid` returns zero frames for a still image, since its `fps` filter has no duration to sample.

`just check` green: 182 passed, pyright strict clean, ruff clean. CI floor 176 → 182.