### PR TITLE
feat: point each mark at the middle of its screen, not at its own edge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             exit 1
           fi
           passed=$(grep -oE '[0-9]+ passed' /tmp/summary | grep -oE '^[0-9]+')
-          if [ "${passed:-0}" -lt 182 ]; then
-            echo "::error::fast lane is ${passed:-no} passed, floor is 182 -- the suite shrank"
+          if [ "${passed:-0}" -lt 187 ]; then
+            echo "::error::fast lane is ${passed:-no} passed, floor is 187 -- the suite shrank"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ knowing about, and it is not a preference — three threshold-based detectors we
 built and measured against a real recording before this one, and all three
 failed. [docs/visual-marks.md](docs/visual-marks.md) has the numbers.
 
+### Retrieving a frame
+
+```python
+from pathlib import Path
+from deixis.media import extract_frame
+
+extract_frame(Path("recording.mov"), 431.5, Path("frame.jpg"), width=1500)
+```
+
+Nothing is precomputed and nothing is cached — the video is already on disk.
+This is the step that makes the index worth having: on a blind-graded set of
+eight questions drawn from the transcript's deictic sentences, an agent with the
+transcript alone scored 5/16, with marks added 7/16, and with frame access
+**16/16**. [docs/do-marks-help.md](docs/do-marks-help.md) has the method.
+
 ## Output
 
 ```jsonc
@@ -135,7 +150,9 @@ failed. [docs/visual-marks.md](docs/visual-marks.md) has the numbers.
   ],
 
   // added by `python -m deixis.frames`; absent until that pass has run
-  "marks": [{"t": 417.0, "score": 2841}],
+  // t    = when the picture changed (the boundary)
+  // look = the frame worth extracting: the middle of the stretch that screen was up
+  "marks": [{"t": 417.0, "score": 2841, "look": 431.5}],
   "marks_meta": {"budget": 150, "min_gap_s": 5.0, "fps": 1.0, "delta": 8,
                  "grid": [128, 84], "frames_sampled": 1997, "source": "..."}
 }
@@ -154,6 +171,12 @@ Two things about this shape are deliberate:
   happens to span that second would invent a relationship nothing observed.
   `marks_meta` travels with it for the same reason `diarization` does — marks
   from a budget of 150 and marks from a budget of 20 are different documents.
+- **`look` is not `t`, and a consumer wanting a frame should use `look`.** A
+  mark is by construction the moment of maximum change, which is the moment the
+  screen is halfway between two states — mid-load skeletons and half-drawn
+  window switches. Measured: a frame at `t` differs from its neighbours in 9.9%
+  of tiles against 2.2% at `look`. Use `t` to know *when*, `look` to know
+  *where to point a camera*.
 
 ## Development
 

--- a/deixis/frames.py
+++ b/deixis/frames.py
@@ -107,16 +107,38 @@ DEFAULT_MIN_GAP_S = 5.0
 
 
 class Mark(NamedTuple):
-    """One moment worth looking at.
+    """One screen, from the moment it appeared to the moment it was replaced.
 
-    `score` is the number of tiles that changed since the previous sample. It
-    is kept rather than dropped because it is the only thing distinguishing a
-    window switch from a scroll, and a consumer deciding which marks to spend a
-    VLM call on needs that ordering.
+    `t` is the boundary -- when the picture changed. `look` is the frame worth
+    actually extracting, and the two are deliberately NOT the same timestamp.
+
+    A mark is by construction the moment of maximum change, which is the moment
+    the screen is mid-way between two states. Measured on the reference
+    recording, a frame at a mark differs from its neighbours in 9.9% of tiles
+    against 2.0% for a frame midway between two marks -- five times less stable
+    -- and 23% of marks sit in the top 5% most unstable seconds of the whole
+    file. In practice that means mid-load skeletons and half-drawn window
+    switches: the single highest-scoring mark on the reference recording is a
+    macOS Mission Control animation, maximum pixel churn and no content at all.
+
+    So `t` answers "when did this screen arrive" and `look` answers "where do I
+    point a camera", which is the midpoint of the stretch during which that
+    screen was up. A consumer wanting a frame should use `look` every time.
+
+    `look` is always >= `t`, and equals it only in the degenerate case of a
+    change on the very last sampled frame -- a segment with no duration to take
+    a midpoint of. That is one mark in 150 on the reference recording, and the
+    honest answer there is the frame itself; there is no later one.
+
+    `score` is the number of tiles that changed at `t`. It is kept because it
+    is the only thing distinguishing a window switch from a scroll -- but note
+    it ranks the size of a TRANSITION, not the interest of the screen that
+    followed, and it should not be read as a relevance signal.
     """
 
     t: float
     score: int
+    look: float
 
 
 def change_scores(tiles: NDArray[np.uint8], delta: int = DEFAULT_DELTA) -> NDArray[np.int32]:
@@ -207,8 +229,19 @@ def select_marks(
             picked.append(idx)
 
     # i indexes the interval between frames i and i+1, so the change is visible
-    # at frame i+1 and that is the timestamp worth seeking to.
-    return sorted(Mark(t=(i + 1) / fps, score=int(scores[i])) for i in picked)
+    # at frame i+1 and that is where the screen begins.
+    if not picked:
+        return []
+    picked.sort()
+    starts = [(i + 1) / fps for i in picked]
+    # The last segment runs to the end of what was sampled, not to the last
+    # mark -- otherwise the final screen, often the one left on display when
+    # the recording stops, would have no frame to look at.
+    ends = [*starts[1:], len(scores) / fps]
+    return [
+        Mark(t=start, score=int(scores[i]), look=(start + end) / 2)
+        for i, start, end in zip(picked, starts, ends, strict=True)
+    ]
 
 
 def with_marks(payload: Payload, marks: list[Mark], meta: dict[str, Any]) -> Payload:
@@ -224,7 +257,9 @@ def with_marks(payload: Payload, marks: list[Mark], meta: dict[str, Any]) -> Pay
     would invent a relationship the detector never observed.
     """
     out = dict(payload)
-    out["marks"] = [{"t": round(m.t, 3), "score": m.score} for m in marks]
+    out["marks"] = [
+        {"t": round(m.t, 3), "score": m.score, "look": round(m.look, 3)} for m in marks
+    ]
     # The parameters travel with the result. Marks from a budget of 150 and
     # marks from a budget of 20 are different documents, and a reader with only
     # the list cannot tell which one they have.

--- a/docs/do-marks-help.md
+++ b/docs/do-marks-help.md
@@ -112,13 +112,37 @@ local instability (tiles differing from the neighbouring frames)
 defined as the moments of maximum change, and a moment of maximum change is by
 construction a moment when the screen is mid-way between two states.
 
-## What follows
+## What followed: `look`
 
-The fix is small and falls out of the two findings together: a mark is a
-**segment boundary**, so the frame worth extracting is the **midpoint between
-consecutive marks**, not the mark itself. That is a few lines on top of what
-exists, and it converts a list of transitions into a list of stable screens —
-which is what a describer or a retriever actually wants.
+The fix falls out of the two findings together, and is now implemented. A mark
+is a **segment boundary**, so every mark carries a second timestamp — `look`,
+the **midpoint of the stretch during which that screen was up**. `t` answers
+"when did this screen arrive"; `look` answers "where do I point a camera".
+
+Measured on the reference recording after the change:
+
+```
+instability of the frame you would send to a vision model
+  at a mark (t)       0.0989
+  at its look         0.0223      <- 4.4x more stable, better on 141/150 marks
+  at a random second  0.0313
+
+same-screen coverage: find t's segment by its boundary, then take the frame at...
+  the boundary itself   0.9476
+  the segment midpoint  0.9753    <- what ships
+  150 random timestamps 0.9161 +/- 0.0061   (~10 sigma below)
+```
+
+One methodological note, because it is the same trap this whole document is
+about. The first attempt at that second table scored the `look` points *as if
+they were boundaries* — searching for the last `look` at or before `t` — and
+returned 0.9102, apparently **worse than random**. That number was an artifact
+of the metric, not a property of the scheme: midpoints are not boundaries, so
+the last `look` before `t` is frequently in the previous segment. Separating
+"which segment is `t` in" (answered by marks) from "which frame represents that
+segment" (answered by `look`) is what the code actually does, and measuring it
+that way gives the table above. A plausible number from the wrong measurement
+nearly buried a working change.
 
 Two things this measurement does not establish:
 

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -148,12 +148,12 @@ def test_the_timestamp_is_the_frame_after_the_change() -> None:
     happened, which is the frame that does not show it.
     """
     marks = select_marks(_scores(0, 42), fps=1.0, budget=1, min_gap_s=0.0)
-    assert marks == [Mark(t=2.0, score=42)]
+    assert marks == [Mark(t=2.0, score=42, look=2.0)]
 
 
 def test_fps_scales_the_timestamps() -> None:
     marks = select_marks(_scores(0, 42), fps=2.0, budget=1, min_gap_s=0.0)
-    assert marks == [Mark(t=1.0, score=42)]
+    assert marks == [Mark(t=1.0, score=42, look=1.0)]
 
 
 def test_the_gap_suppresses_a_neighbour_however_high_it_scores() -> None:
@@ -196,6 +196,60 @@ def test_the_gap_is_measured_in_seconds_not_in_frames() -> None:
     assert len(select_marks(scores, fps=2.0, budget=2, min_gap_s=1.5)) == 2
 
 
+def test_look_is_the_middle_of_the_screen_not_its_first_instant() -> None:
+    """A mark is the moment of maximum change, so it is the worst frame to grab.
+
+    Measured on the reference recording: a frame at a mark differs from its
+    neighbours in 9.9% of tiles against 2.0% midway between marks. `look` must
+    therefore sit halfway to the NEXT mark, never on the boundary itself.
+    """
+    # Screens begin at t=1 and t=6; 10 intervals, so the file ends at t=10.
+    marks = select_marks(
+        _scores(90, 0, 0, 0, 0, 80, 0, 0, 0, 0), fps=1.0, budget=2, min_gap_s=0.0
+    )
+    assert [(m.t, m.look) for m in marks] == [(1.0, 3.5), (6.0, 8.0)]
+
+
+def test_the_last_look_runs_to_the_end_of_the_recording() -> None:
+    """Not to the last mark.
+
+    The final screen is often the one left on display when recording stopped.
+    Ending the last segment at its own start would give it a `look` equal to
+    `t` -- the one frame this whole field exists to avoid.
+    """
+    (mark,) = select_marks(_scores(*([50] + [0] * 19)), fps=1.0, budget=1, min_gap_s=0.0)
+    assert mark.t == 1.0
+    assert mark.look == 10.5  # midway between t=1 and the end at t=20
+
+
+def test_look_scales_with_fps_like_t_does() -> None:
+    marks = select_marks(_scores(90, 0, 0, 80, 0, 0), fps=2.0, budget=2, min_gap_s=0.0)
+    assert [(m.t, m.look) for m in marks] == [(0.5, 1.25), (2.0, 2.5)]
+
+
+def test_look_never_precedes_its_own_mark() -> None:
+    """The invariant, including the one case where they coincide.
+
+    A change on the very last sampled frame opens a segment with no duration,
+    so its midpoint is itself. One mark in 150 on the reference recording. What
+    must never happen is `look` landing BEFORE `t` -- that would point at the
+    screen being replaced rather than the one that arrived.
+    """
+    marks = select_marks(_scores(*([7] * 40)), fps=1.0, budget=40, min_gap_s=0.0)
+    assert len(marks) > 1
+    assert all(m.look >= m.t for m in marks)
+    assert marks[-1].look == marks[-1].t  # the last interval has nothing after it
+
+
+def test_no_marks_means_no_segments_rather_than_a_crash() -> None:
+    """The empty case has no start to pair the recording's end with.
+
+    Zipping one end against zero starts raised, which the zero-score and
+    zero-budget tests caught on the first run of this feature.
+    """
+    assert select_marks(_scores(0, 0, 0), fps=1.0, budget=5, min_gap_s=0.0) == []
+
+
 def test_zero_scores_are_never_marked() -> None:
     """A budget is a ceiling, not a quota.
 
@@ -216,7 +270,7 @@ def test_no_scores_yield_nothing() -> None:
 
 def test_ties_break_toward_the_earlier_frame() -> None:
     marks = select_marks(_scores(5, 5, 5), fps=1.0, budget=1, min_gap_s=0.0)
-    assert marks == [Mark(t=1.0, score=5)]
+    assert marks == [Mark(t=1.0, score=5, look=2.0)]
 
 
 def test_ties_break_the_same_way_at_a_size_that_changes_the_sort() -> None:
@@ -231,7 +285,7 @@ def test_ties_break_the_same_way_at_a_size_that_changes_the_sort() -> None:
     """
     scores = np.concatenate([np.zeros(5, dtype=np.int32), np.full(300, 3, dtype=np.int32)])
     marks = select_marks(scores, fps=1.0, budget=1, min_gap_s=0.0)
-    assert marks == [Mark(t=6.0, score=3)]
+    assert marks == [Mark(t=6.0, score=3, look=155.5)]
 
 
 def test_a_zero_budget_returns_nothing() -> None:
@@ -260,14 +314,14 @@ def test_nonsense_parameters_are_rejected(kwargs: dict[str, float], match: str) 
 
 def test_marks_are_added_beside_the_sentences() -> None:
     payload = {"audio": "a.mov", "sentences": [{"start": 0.0}]}
-    out = with_marks(payload, [Mark(t=1.5, score=9)], {"budget": 1})
-    assert out["marks"] == [{"t": 1.5, "score": 9}]
+    out = with_marks(payload, [Mark(t=1.5, score=9, look=4.0)], {"budget": 1})
+    assert out["marks"] == [{"t": 1.5, "score": 9, "look": 4.0}]
     assert out["sentences"] == payload["sentences"]
 
 
 def test_the_original_payload_is_left_alone() -> None:
     payload: dict[str, object] = {"sentences": []}
-    with_marks(payload, [Mark(t=1.0, score=1)], {})
+    with_marks(payload, [Mark(t=1.0, score=1, look=1.0)], {})
     assert "marks" not in payload
 
 


### PR DESCRIPTION
Closes the finding from PR #2: a mark points at the **least readable** frame in its neighbourhood, because the moment of maximum change is the moment the screen is halfway between two states.

Each mark now carries a second timestamp:

```jsonc
{"t": 417.0, "score": 2841, "look": 431.5}
//  t    = when the picture changed (the boundary)
//  look = the frame worth extracting (middle of the stretch that screen was up)
```

## Measured on the reference recording

```
instability of the frame you would send to a vision model
  at a mark (t)       0.0989
  at its look         0.0223     <- 4.4x more stable, better on 141/150 marks
  at a random second  0.0313

same-screen coverage: find t's segment by its boundary, then take the frame at...
  the boundary itself   0.9476
  the segment midpoint  0.9753   <- what ships
  150 random timestamps 0.9161 +/- 0.0061   (~10 sigma below)
```

Both acceptance criteria on the bead are met, including the random baseline that went unrun the first time around.

## One methodological note, recorded rather than quietly fixed

The coverage table was **wrong on the first attempt** and returned 0.9102 — apparently *worse than random*. The cause was the metric, not the scheme: it scored the midpoints as if they were boundaries, searching for the last `look` at or before `t`. Midpoints are not boundaries, so that lookup often lands in the previous segment.

Separating "which segment is `t` in" (answered by marks) from "which frame represents that segment" (answered by `look`) is what the code actually does. A plausible number from the wrong measurement nearly buried a working change — the same failure mode as the rest of this feature's history, so it is written into `docs/do-marks-help.md`.

## Edge cases

`look >= t` always, equal only for a change on the very last sampled frame, where the segment has no duration — one mark in 150 on the reference recording. Pinned by test.

The empty-marks case raised from `zip(strict=True)` on the first run, pairing one segment end against zero starts. Caught by the existing zero-score and zero-budget tests, fixed with an early return, now pinned explicitly.

## Verification

`just check` green: 187 passed, pyright strict clean, ruff clean. Four mutants against the new logic (`look=start`, `look=end`, last segment ending at the last mark, segments shifted by one) — all killed. Re-ran end to end on the real 33-minute recording: 150 marks in 123s, `look−t` median 4.5s / p90 13.1s / max 39.5s.

CI floor 182 → 187.