### PR TITLE
test: the marks against eight more videos and an external benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ in the meeting and, as text, it is worthless. The referent was on screen.
 | | |
 |---|---|
 | **Transcript half** | working — ingestion, chunked ASR, resume, optional speaker labels |
-| **Visual marks** | working — the moments the picture changed, written into the transcript. No description attached. [Measured](docs/do-marks-help.md) to be worth little on their own |
+| **Visual marks** | working — the moments the picture changed. [Validated externally](docs/generalisation.md) against human annotations (p < 0.0001), but [worth little on their own](docs/do-marks-help.md) for answering questions |
 | **Frame retrieval** | working — `media.extract_frame(video, t, dest)`. This is what actually makes a recording answerable: 5/16 → 16/16 on a blind-graded question set |
 | **Frame description** | **not built**, and now blocked on a *measured* finding rather than an unmeasured one. See [Roadmap](#roadmap) |
 
@@ -198,6 +198,7 @@ can fail. That cost is the point — see [docs/tooling-gaps.md](docs/tooling-gap
 | [docs/resume-gate-design.md](docs/resume-gate-design.md) | how you test a resume that silently restarts, given it produces byte-identical output |
 | [docs/mutmut-triage.md](docs/mutmut-triage.md) | every surviving mutant and why it is accepted |
 | [docs/visual-marks.md](docs/visual-marks.md) | the three change detectors that were built and measured before this one, and why each failed |
+| [docs/generalisation.md](docs/generalisation.md) | eight more recordings plus GUI-World, the external benchmark: marks match human change annotations at p < 0.0001 |
 | [docs/do-marks-help.md](docs/do-marks-help.md) | do the marks actually help an agent? Three arms, blind-graded: 5/16 → 7/16 → 16/16 |
 | [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Measured: not this one |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ likely to be useful.
 | [resume-gate-design.md](resume-gate-design.md) | How you test a resume that silently restarts, given that it produces byte-identical output. The design behind `scratch/resume_gate.py` and `tests/test_resume_gate.py`. |
 | [mutmut-triage.md](mutmut-triage.md) | Every mutant the test suite fails to kill, and why each one is accepted. Read this before adding a suppression. |
 | [visual-marks.md](visual-marks.md) | Three change detectors built, measured on a real recording, and thrown away — and the premise failure underneath all three. Why the shipped one has a budget and no threshold. |
+| [generalisation.md](generalisation.md) | Does any of it hold off the reference recording? Eight local videos, an external benchmark with human ground truth (p < 0.0001), and the sampling-rate sweep that proved a confident assumption wrong. |
+| [datasets-surveyed.md](datasets-surveyed.md) | Every public dataset considered as external ground truth for screen-recording change detection, with what each one's annotations actually are and why eight of them were rejected. |
 | [do-marks-help.md](do-marks-help.md) | A three-arm, blind-graded measurement of whether the marks actually improve a downstream agent. Transcript only 5/16, plus marks 7/16, plus frame access 16/16 — and the marks turn out to point at the least readable instant in their neighbourhood. |
 | [vlm-legibility.md](vlm-legibility.md) | Whether a small local VLM can read dense on-screen text. Ground truth written before the model ran; the answer is no, and the reason is hallucination rather than resolution. |
 

--- a/docs/datasets-surveyed.md
+++ b/docs/datasets-surveyed.md
@@ -1,0 +1,115 @@
+# Public datasets for evaluating screen-recording change-point detection
+
+Investigated 2026-08-09. Every row below was checked by opening the dataset page,
+README, or paper — not recalled. Where I could not confirm something, it says so.
+
+Requirement recap: screen content (not natural film), ground-truth timestamps saying
+"at time T something changed", downloadable today without an institutional agreement,
+and a few-GB slice must be pullable.
+
+## Ranked candidates
+
+| # | Dataset | What the temporal annotations actually are | Distribution | Licence | Size | URL |
+|---|---|---|---|---|---|---|
+| 1 | **GUI-World** (ICLR 2025) | Per-video `keyframes` list: integer **frame index** + `sub_goal` + mouse/keyboard action. Human-annotated. Verified on `software.jsonl`: 496 benchmark videos, 2,401 keyframes, mean 4.8/video (min 2, max 17). Videos are 30 fps 1920×1080, so `frame/30` = seconds. | **Video files hosted directly on HF** as `.mp4`/`.mov`. Annotations as `.jsonl`. No YouTube step. | **CC BY 4.0** (stated in the HF README) | Whole repo ≈ 94 GB across 6 dirs (software 63.7 GB / 4,720 files, website 12.7 / 2,499, multi 8.6 / 475, IOS 7.3 / 492, android 0.9 / 3,800, XR 0.6 / 393). Individual videos 3–30 MB — a 50-video slice is ~1 GB. | https://huggingface.co/datasets/shuaishuaicdp/GUI-World · mirror `ONE-Lab/GUI-World` · code https://github.com/Dongping-Chen/GUI-World |
+| 2 | **MaViLS** (Interspeech 2024) | Human raters map **each transcribed sentence (with a video timestamp) to a slide number**. Slide-change times are derivable wherever the slide index increments between consecutive sentences — so boundary precision is bounded by sentence granularity, not frame-exact. | Split: code + transcripts + ground-truth **Excel** files + slide PDFs on GitHub; **videos on Kaggle** (free account required). | Code Apache-2.0. **Dataset licence not stated** on the repo page — unresolved. | 20 lectures, >22 h total, so ~66 min average — this is the only candidate whose video length matches a 33-minute Teams recording. Byte size not stated on the Kaggle page I could load. | https://github.com/andererka/mavils · videos https://kaggle.com/datasets/e98bcdecedc67af45204338260556f932f8ec426b81caed0130d2cce80c4ea84 |
+| 3 | **SeeAction** (ICSE 2025, distinguished paper) | 7,260 video–action pairs over 288 screencasts (12.8 h) of Word, Zoom, Firefox, Photoshop, Windows 10 Settings. Actions are `[command][widget][location]`. | Single **Google Drive zip**, linked from the README. | **Not stated** in the README. | 288 videos / 12.8 h; byte size not stated. | https://github.com/DehaiZhao/SeeAction · paper https://arxiv.org/abs/2503.12873 |
+| 4 | **PsTuts** (CVPR 2020) | Adobe Photoshop screencast tutorials with low-level and high-level semantic labels and temporal segmentation into action clips. | **Google Drive** folder containing both the pre-segmented clips and the original full tutorial videos. | Code Apache-2.0; dataset licence not stated in README. | Not stated. | https://github.com/KunpengLi1994/PsTuts · https://sites.google.com/view/pstuts/ |
+| 5 | **VidChapters-7M** (NeurIPS 2023 D&B) | User-written YouTube chapter titles + start timestamps. Real segment boundaries, but the corpus is general YouTube — screen content is a small unlabelled minority you would have to filter for yourself. | **Annotations only.** Video IDs; you download with yt-dlp. Link rot applies. | Code MIT; dataset licence stated as "its own licence" and I could not open a page giving its text. | 817K videos / 7M chapters. Any slice you want. | https://github.com/antoyang/VidChapters · https://antoyang.github.io/vidchapters.html |
+
+## Checked and rejected
+
+| Dataset | Why it does not work |
+|---|---|
+| **COIN** | 11,827 YouTube videos, 476 h, 46,354 step segments with time boundaries — the annotation shape is right, but the 180 tasks are nursing, vehicles, appliances, cooking, sports. **No software/computer tasks.** Also requires a **signed licence agreement emailed to the maintainer** — fails the "downloadable now" bar. https://coin-dataset.github.io/ |
+| **Mind2Web** | Does contain "video recordings during annotation" in the raw dump, but the dump ships via **Globus at Ohio Supercomputer Center**, and the released annotations are per-step HTML/screenshot pairs, not timestamps into those videos. CC BY 4.0. Not usable as temporal ground truth without doing the alignment yourself. https://github.com/OSU-NLP-Group/Mind2Web |
+| **VideoGUI** | Checked `VideoGUI/VideoGUI-Mid-Plan` on HF: 462 rows of **start/end screenshot pairs** plus text, parquet, no video and no timestamps. Full recordings live behind Google Drive links. Not a change-point benchmark. https://huggingface.co/datasets/VideoGUI/VideoGUI-Mid-Plan |
+| **SliTraNet** | Method and pretrained weights are on GitHub; the FAU Erlangen lecture corpus (30 videos, frame-level hard/gradual transition GT) is **not linked anywhere in the repo** — the README only describes an expected folder layout. Would need to email the authors. https://github.com/asindel/SliTraNet |
+| **"Slidin' Videos"** (ITU AI for Good) | ~3,000 slide transitions with start/end frames over 240 presentations — exactly the right annotation. The event page describes it but publishes **no download link, no licence, no repo**. Dead end without contacting ITU. https://aiforgood.itu.int/event/slidin-videos-slide-transition-detection-and-title-extraction-in-lecture-videos/ |
+| **Sharingan** (arXiv 2411.08768, Microsoft) | Paper describes "a basic self-curated dataset and an advanced benchmark adapted from prior work". I could find **no release URL** on the arXiv page, the HF paper page, or the MSR publication page. Treat as unreleased. |
+| **CodeSCAN** | 12,000 **static screenshots** of VS Code, not video. Annotations are IDE element boxes / OCR. Wrong modality. https://arxiv.org/abs/2409.18556 |
+| **AITW / AndroidControl / GUI-Odyssey / ScreenSpot / Screen2Words / Rico** | All are screenshot-and-action-tuple corpora, not continuous video with time axes. Nothing to compute a change *time* against. (Not individually page-verified — rejected on modality, which is uncontested in their own titles.) |
+| **WebArena / VisualWebArena** | Interactive environments, not recorded video corpora. |
+
+## Recommendation
+
+**Use GUI-World's `software` benchmark split.** It is the only thing I found that is
+simultaneously (a) genuine desktop screen recordings, (b) hosted as real video files
+needing no scraping, (c) carrying human-placed per-frame change timestamps, and (d) under
+a clean CC BY 4.0 licence.
+
+Mapping to our metric: for video `software/N.mp4`, ground-truth change times are
+`[k["frame"]/30 for k in row["keyframes"]]` seconds. Score our top-N output against those
+with a tolerance window (±1 s is the natural floor given we sample at 1 fps).
+
+### The one real caveat
+
+These clips are **short**. Estimating each video's length from its last keyframe index
+across all 496 benchmark rows: median ≈ 15 s, p75 ≈ 21 s, max ≈ 110 s, ~2.3 h total.
+A 15-second clip with 5 keyframes has a change roughly every 3 seconds — a much denser
+change rate than a 33-minute meeting recording, and at 1 fps we only get ~15 samples per
+clip. So GUI-World tests *precision of localisation on dense GUI activity*; it does not
+test *sparse change detection over a long recording*. For that second axis, **MaViLS**
+(20 lectures × ~66 min) is the complement, at the cost of a Kaggle account and
+sentence-granular rather than frame-exact boundaries.
+
+Recommended plan: GUI-World as the primary automated benchmark now; MaViLS as a
+second, long-form check if the length mismatch turns out to matter.
+
+### Exact commands for a small slice
+
+Verified working on this machine (`hf` 1.26.0). Note the filenames must be **positional**
+— passing them to `--include` alongside positionals makes `hf` warn and ignore the
+`--include`.
+
+```bash
+# 1. Annotations only (2.7 MB) — inspect before pulling any video
+hf download shuaishuaicdp/GUI-World Annotation/benchmark/software.jsonl \
+  --repo-type dataset --local-dir ./data/gui-world
+
+# 2. Pick the first 20 software videos referenced by the benchmark annotations
+python3 - <<'PY'
+import json, subprocess
+rows = [json.loads(l) for l in open('./data/gui-world/Annotation/benchmark/software.jsonl')]
+paths = [r['video_path'] for r in rows[:20]]
+subprocess.run(['hf','download','shuaishuaicdp/GUI-World',*paths,
+                '--repo-type','dataset','--local-dir','./data/gui-world'], check=True)
+PY
+# ~20 files x 3-30 MB = roughly 300-400 MB
+```
+
+Ground-truth extraction:
+
+```python
+import json
+FPS = 30  # verified: software/0.mp4 is 1920x1080, avg_frame_rate=30/1, 21.37 s, 641 frames
+for row in map(json.loads, open('Annotation/benchmark/software.jsonl')):
+    gt_seconds = [k['frame'] / FPS for k in row['keyframes']]
+    yield row['video_path'], gt_seconds
+```
+
+Confirm the fps per file rather than assuming 30 globally — I probed one video, not all of
+them:
+
+```bash
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=avg_frame_rate,nb_frames -show_entries format=duration \
+  -of default=noprint_wrappers=1 software/0.mp4
+```
+
+### What was actually observed vs. inferred
+
+- Observed: `software/0.mp4` downloads (HTTP 200, 9,016,054 bytes), probes as
+  1920×1080, `avg_frame_rate=30/1`, duration 21.367 s, 641 frames; its annotation's last
+  keyframe is frame 621, consistent with 30 fps.
+- Observed: `software.jsonl` parses to 496 rows, 2,401 keyframes, systems
+  `{Windows, macOS}`.
+- Observed: directory file counts and byte totals via the HF tree API.
+- Observed: `hf download` with positional filenames fetches both an annotation file and a
+  video into `--local-dir`.
+- Inferred, not observed: the duration statistics (median 15 s etc.) are lower bounds
+  computed from last-keyframe indices, not from probing all 496 files. The other five
+  directories were not probed at all.
+- Not confirmed: MaViLS dataset licence, MaViLS/SeeAction/PsTuts byte sizes, the
+  VidChapters dataset licence text, and the SeeAction annotation file format (the README
+  links a Drive zip but does not document its schema).

--- a/docs/generalisation.md
+++ b/docs/generalisation.md
@@ -1,0 +1,139 @@
+# Does any of this hold on a video that is not the reference recording?
+
+Every number in [visual-marks.md](visual-marks.md) and
+[do-marks-help.md](do-marks-help.md) came from one 33-minute Microsoft Teams
+recording on one laptop. That is n=1, and n=1 is a demo. This is the check.
+
+Three experiments: eight local recordings, an external benchmark with human
+ground truth, and a sampling-rate sweep. Two of the three changed what the
+project believes.
+
+## 1. Eight local recordings — does the `look` idea generalise?
+
+`scratch/mark_eval.py` runs the shipped code on any video and scores two things
+against a random baseline of the same size. No ground truth needed; both metrics
+are computed from the video's own pixels.
+
+- **Instability** — how settled is the frame you would send to a vision model?
+- **Coverage** — pick any second, find its segment by the mark boundaries, take
+  that segment's `look` frame: does it show the same screen?
+
+```
+video                        dur  mks | inst@t  @look   @rnd    x | cov@look  @rnd  sigma
+2024-11-14 17-21-27.mkv       40    3 |  0.542  0.157  0.126  3.5 |    0.885 0.664    1.5
+2024-11-14 17-23-06.mkv       50    4 |  0.646  0.174  0.139  3.7 |    0.874 0.613    2.2
+2024-11-14 17-23-57.mkv       51    4 |  0.491  0.069  0.189  7.2 |    0.796 0.541    2.6
+2024-11-14 17-33-37.mkv      107    8 |  0.340  0.180  0.139  1.9 |    0.862 0.678    2.2
+2024-11-14 17-26-56.mkv      401   30 |  0.256  0.135  0.067  1.9 |    0.937 0.832    3.6
+hack-pearl 2026-06-06         16    2 |  0.093  0.052  0.060  1.8 |    0.928 0.915    0.8
+Teams 2026-08-06            1997  150 |  0.099  0.022  0.028  4.4 |    0.975 0.916    9.7
+Teams 2026-07-31            4428  332 |  0.183  0.049  0.057  3.7 |    0.944 0.833   18.8
+```
+
+Two resolutions (1920x1080 OBS captures, 2940x1912 macOS), 16 seconds to 74
+minutes, clearly different content.
+
+- **`look` is more stable than `t` on 8/8**, by 1.8x to 7.2x. The midpoint idea
+  is not an artifact of the reference recording.
+- **`look` beats random coverage on 8/8**, by 0.8 to 18.8 sigma. The one weak
+  case is the 16-second clip with two marks, which is too short to say anything.
+
+But one column does **not** generalise, and it is worth saying plainly:
+
+- **`look` beats random on *instability* only 4/8.** On the short OBS clips a
+  random frame is often calmer than a `look` frame (0.157 vs 0.126, 0.174 vs
+  0.139, 0.180 vs 0.139, 0.135 vs 0.067). Marks cluster where the action is, so
+  their midpoints inherit some of that; random spreads into the dead air.
+
+The two metrics are answering different questions and the split is the honest
+result. Random gets you a calmer frame; `look` gets you a frame that *represents
+the second you asked about*. For enumerating a recording the second is what
+matters, and `look` wins that 8/8.
+
+## 2. GUI-World — an external benchmark with human ground truth
+
+[GUI-World](https://huggingface.co/datasets/shuaishuaicdp/GUI-World) (ICLR 2025,
+CC BY 4.0) is 496 desktop screen recordings whose **keyframes were placed by
+human annotators** at the moments a user action changed the screen. Nobody here
+produced that ground truth, which is the entire point of using it.
+
+Method: 40 videos from the `software` benchmark split (one, `software/165.mp4`,
+is truncated on the hub and is skipped and named rather than silently dropped).
+For each video the budget is set to **exactly the number of human keyframes**,
+so the comparison is like-for-like, and the baseline is 200 draws of the same
+number of uniformly random timestamps.
+
+```
+39 videos scored
+mean distance from a human keyframe to the nearest mark
+    ours    0.79s
+    random  1.36s
+ours closer on 37 / 38 videos          one-sided sign test  p < 0.0001
+```
+
+**The marks find human-annotated change moments, and they beat chance
+decisively.** This is an external, repeatable result on data from another
+research group, and it is the strongest evidence the detector has.
+
+### Why this does not contradict the deictic result
+
+[do-marks-help.md](do-marks-help.md) found the marks *losing* to random at
+pointing to the moments that needed a frame (median 8.9s vs 4.7s). Both results
+are correct and they measure different targets:
+
+| Target | Nature | Marks |
+|---|---|---|
+| GUI-World keyframes | *user acted, the screen changed* — transitions | **win, p < 0.0001** |
+| Deictic sentences | *speaker explains what is already on screen* — plateaus | **lose to random** |
+
+A change detector finds changes. It does not find explanations, and explanation
+happens after the change, while the screen sits still. Neither result is a bug;
+together they say precisely what the marks are for.
+
+## 3. The sampling rate — 1 fps is the best setting, not a compromise
+
+The default is 1 fps and it looked like a decode-cost concession. Measured on
+GUI-World across four rates:
+
+```
+fps=1  ours 0.79s vs random 1.36s   37/38 videos   p < 0.0001
+fps=2  ours 0.84s vs random 1.31s   34/39          p < 0.0001
+fps=4  ours 1.00s vs random 1.31s   30/39          p = 0.0005
+fps=8  ours 1.11s vs random 1.31s   28/39          p = 0.0047
+```
+
+Accuracy degrades **monotonically as sampling gets finer.** The first version of
+the benchmark harness defaulted to 4 fps and its docstring argued that 1 fps
+would be too coarse for 15-second clips — a confident claim, written before
+measuring, and wrong. It has been corrected in place rather than quietly fixed.
+
+Likely mechanism, **untested**: with more samples per transition, several marks
+land inside one change event and a fixed budget gets spent twice on the same
+moment; coarse sampling forces them apart.
+
+## What this run establishes, and what it does not
+
+**Established:**
+
+- The `look` midpoint beats the mark itself on every video tried (8/8).
+- Marks match human change annotations far better than chance on an external,
+  third-party benchmark (p < 0.0001, 39 videos).
+- 1 fps is the right default, on evidence rather than convenience.
+- The pipeline runs unmodified on 1920x1080 OBS captures and 2940x1912 macOS
+  captures, on clips from 16 seconds to 74 minutes.
+
+**Not established:**
+
+- GUI-World clips are short (median ~15s, dense actions). Long-form sparse
+  change is only tested on the two local Teams recordings.
+- The eight local videos have no ground truth; their metrics are self-supervised
+  and can only compare schemes, never confirm that a mark is *interesting*.
+- Nothing here re-tests whether marks help an *agent*. That measurement remains
+  the one in [do-marks-help.md](do-marks-help.md), n=8 questions, one recording.
+- No lecture, no coding session, no browser-only session.
+
+The closest complement for long-form ground truth is
+[MaViLS](https://github.com/andererka/mavils) — 20 lectures, ~66 minutes each,
+sentence-to-slide alignment — which needs a Kaggle account and gives boundaries
+only at sentence granularity. [datasets-surveyed.md](datasets-surveyed.md) records that survey,
+including the eight candidates that were checked and rejected.

--- a/scratch/guiworld_eval.py
+++ b/scratch/guiworld_eval.py
@@ -1,0 +1,162 @@
+"""Score deixis' marks against GUI-World's human-annotated keyframes.
+
+The external benchmark. Every other number about this detector was measured on
+recordings from one laptop; GUI-World (ICLR 2025, CC BY 4.0) is 496 desktop
+screen recordings with human-placed keyframes marking the moments a user action
+changed the screen. That is ground truth nobody here produced.
+
+The question: given the SAME number of timestamps a human annotator placed, do
+our change-ranked marks land nearer those moments than random timestamps do?
+Random is the baseline that matters and the one this project skipped once.
+
+Budget is set to exactly the number of human keyframes in that video, so the
+comparison is like-for-like rather than "who emits more guesses".
+
+A note on --fps, because the first version of this file asserted the opposite
+and was wrong. These clips are short (median ~15s), so it looked obvious that
+1 fps would be too coarse -- ~15 samples, quantisation error comparable to the
+inter-event spacing -- and the default here was 4. Measured across 1/2/4/8 fps,
+1 fps is the BEST setting and accuracy degrades monotonically as sampling gets
+finer:
+
+    fps=1  ours 0.79s vs random 1.36s   37/38 videos
+    fps=2  ours 0.84s vs random 1.31s   34/39
+    fps=4  ours 1.00s vs random 1.31s   30/39
+    fps=8  ours 1.11s vs random 1.31s   28/39
+
+The likely mechanism, untested: with more samples per transition, several marks
+land inside one change event and the fixed budget is spent twice on the same
+moment. Coarse sampling forces them apart. Whatever the cause, the shipped 1 fps
+default is not a compromise made for decode cost -- it is the better choice on
+this benchmark.
+
+Usage: python scratch/guiworld_eval.py [--fps 4] [--limit 40]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from deixis.frames import GRID_H, GRID_W, change_scores, select_marks
+from deixis.media import extract_tile_grid
+
+ROOT = Path(__file__).resolve().parent / "guiworld"
+ANN = ROOT / "Annotation" / "benchmark" / "software.jsonl"
+
+
+def video_fps(path: Path) -> float | None:
+    """The real frame rate, probed, or None if the file will not open.
+
+    None rather than a raise: one of the 40 files downloaded from the hub is
+    truncated (120 KB, "moov atom not found"). Skipping it and SAYING SO is
+    right; crashing the sweep on it, or silently dropping it, are both wrong.
+    """
+    import subprocess
+
+    proc = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=avg_frame_rate", "-of", "csv=p=0", str(path)],
+        capture_output=True, text=True, check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    num, _, den = proc.stdout.strip().partition("/")
+    return float(num) / float(den or 1)
+
+
+def nearest(points: np.ndarray, targets: np.ndarray) -> np.ndarray:
+    """Distance in seconds from each target to the closest point."""
+    return np.array([np.abs(points - t).min() for t in targets])
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--limit", type=int, default=40)
+    ap.add_argument("--draws", type=int, default=200)
+    args = ap.parse_args()
+
+    rows = [json.loads(line) for line in ANN.open()]
+    rng = np.random.default_rng(0)
+    ours: list[float] = []
+    rand: list[float] = []
+    per_video: list[dict[str, float | str | int]] = []
+    skipped: list[str] = []
+
+    for row in rows:
+        path = ROOT / row["video_path"]
+        if not path.exists():
+            continue
+        if len(per_video) >= args.limit:
+            break
+
+        native = video_fps(path)
+        if native is None or native <= 0:
+            skipped.append(row["video_path"])
+            continue
+        gt = np.array(sorted(k["frame"] / native for k in row["keyframes"]))
+        tiles = extract_tile_grid(path, fps=args.fps, width=GRID_W, height=GRID_H)
+        duration = len(tiles) / args.fps
+        # A keyframe past the decoded end is an annotation we cannot be scored
+        # on; drop it rather than let it inflate both sides equally.
+        gt = gt[gt <= duration]
+        if len(gt) < 2 or len(tiles) < 4:
+            continue
+
+        scores = change_scores(tiles)
+        marks = select_marks(scores, fps=args.fps, budget=len(gt), min_gap_s=0.0)
+        if len(marks) < 1:
+            continue
+        mine = nearest(np.array([m.t for m in marks]), gt)
+
+        # Same count of timestamps, drawn uniformly over the same span.
+        draws = [
+            nearest(np.sort(rng.uniform(0, duration, len(marks))), gt).mean()
+            for _ in range(args.draws)
+        ]
+        ours.append(float(mine.mean()))
+        rand.append(float(np.mean(draws)))
+        per_video.append({
+            "video": row["video_path"],
+            "app": row.get("app", "?"),
+            "duration_s": round(duration, 1),
+            "gt": len(gt),
+            "ours_s": round(float(mine.mean()), 2),
+            "random_s": round(float(np.mean(draws)), 2),
+        })
+
+    o, r = np.array(ours), np.array(rand)
+    print(f"{'video':<18}{'app':<22}{'dur':>6}{'gt':>4}{'ours':>7}{'random':>8}  winner")
+    for v in per_video:
+        w = "ours" if v["ours_s"] < v["random_s"] else "random"  # type: ignore[operator]
+        print(f"{v['video']!s:<18}{str(v['app'])[:21]:<22}{v['duration_s']:>6}"
+              f"{v['gt']:>4}{v['ours_s']:>7}{v['random_s']:>8}  {w}")
+
+    wins = int((o < r).sum())
+    if skipped:
+        print(f"\nSKIPPED (unreadable file): {', '.join(skipped)}")
+    print(f"\nvideos scored            : {len(o)}")
+    print(f"mean distance to a human keyframe -- ours {o.mean():.2f}s  random {r.mean():.2f}s")
+    print(f"ours closer on           : {wins}/{len(o)} videos")
+    # Sign test: how surprising is that win count if the two were equivalent?
+    from math import comb
+    n = len(o)
+    p = sum(comb(n, k) for k in range(wins, n + 1)) / 2**n
+    print(f"one-sided sign test      : p = {p:.4f}")
+    Path("scratch/eval/guiworld.json").write_text(
+        json.dumps({"per_video": per_video, "wins": wins, "n": n,
+                    "mean_ours": float(o.mean()), "mean_random": float(r.mean()),
+                    "p": p, "fps": args.fps}, indent=1)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/mark_eval.py
+++ b/scratch/mark_eval.py
@@ -1,0 +1,155 @@
+"""Score the mark scheme on any video, against a random baseline.
+
+The repeatable test. Everything deixis knows about its own change detection came
+from one 33-minute recording, which is n=1. This harness runs the shipped code
+on an arbitrary video and reports the two things that decide whether the marks
+are worth having -- with no ground truth needed, because both metrics are
+self-supervised on the video's own pixels:
+
+  FRAME QUALITY   How settled is the frame you would send to a vision model?
+                  Measured as the fraction of tiles differing from the frames
+                  either side of it. A mark sits on a transition by definition,
+                  so `t` should score badly and `look` should score well. If
+                  `look` is not clearly better than `t`, the midpoint idea is
+                  wrong for this video.
+
+  COVERAGE        Pick any second of the video. Find its segment by the mark
+                  boundaries, take that segment's `look` frame -- does it show
+                  the same screen? This is what a consumer enumerating a video
+                  actually does.
+
+Both are compared against N random draws of the same number of timestamps.
+Random is the baseline that matters (Principles of Visual Tokens, ICCV 2025:
+random sampling matches or beats most sophisticated frame selection), and it is
+the baseline this project skipped once already.
+
+Usage:
+  python scratch/mark_eval.py <video> [--fps 1] [--per-min 4.5] [--json out.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from deixis.frames import GRID_H, GRID_W, change_scores, select_marks
+from deixis.media import extract_tile_grid
+
+DELTA = 8
+RANDOM_DRAWS = 30
+
+
+def instability(tiles: np.ndarray, i: float) -> float:
+    """How much the frame at index i differs from the frames either side of it."""
+    j = max(1, min(int(i), len(tiles) - 2))
+    back = (np.abs(tiles[j] - tiles[j - 1]) > DELTA).mean()
+    fwd = (np.abs(tiles[j + 1] - tiles[j]) > DELTA).mean()
+    return float((back + fwd) / 2)
+
+
+def same_screen(tiles: np.ndarray, a: float, b: float) -> float:
+    """Fraction of tiles unchanged between the frames at a and b."""
+    n = len(tiles) - 1
+    return float((np.abs(tiles[min(int(a), n)] - tiles[min(int(b), n)]) <= DELTA).mean())
+
+
+def coverage(tiles: np.ndarray, boundaries: np.ndarray, samples: np.ndarray) -> float:
+    """Average same-screen score over every second, via each second's segment.
+
+    Boundaries and samples are separate on purpose. Finding which segment a
+    second belongs to is the boundaries' job; representing that segment with a
+    frame is the samples' job. Conflating them scores midpoints as if they were
+    boundaries and makes a working scheme look worse than random -- which it
+    did, the first time this was measured.
+    """
+    return float(
+        np.mean([
+            same_screen(tiles, samples[max(0, int(np.searchsorted(boundaries, t, "right")) - 1)], t)
+            for t in range(1, len(tiles) - 1)
+        ])
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("video")
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--per-min", type=float, default=4.5, help="marks per minute of video")
+    ap.add_argument("--min-gap", type=float, default=5.0)
+    ap.add_argument("--json", help="append the result to this JSON-lines file")
+    args = ap.parse_args()
+
+    name = Path(args.video).name
+    t0 = time.monotonic()
+    tiles = extract_tile_grid(Path(args.video), fps=args.fps, width=GRID_W, height=GRID_H)
+    decode_s = time.monotonic() - t0
+    minutes = len(tiles) / (args.fps * 60.0)
+    budget = max(2, round(args.per_min * minutes))
+
+    scores = change_scores(tiles)
+    marks = select_marks(scores, fps=args.fps, budget=budget, min_gap_s=args.min_gap)
+    if len(marks) < 2:
+        print(f"{name}: only {len(marks)} marks -- too short or too static to score")
+        return 0
+
+    ti = tiles.astype(np.int16)
+    starts = np.array([m.t for m in marks])
+    looks = np.array([m.look for m in marks])
+
+    at_t = float(np.mean([instability(ti, x) for x in starts]))
+    at_look = float(np.mean([instability(ti, x) for x in looks]))
+    cov_t = coverage(ti, starts, starts)
+    cov_look = coverage(ti, starts, looks)
+
+    rng = np.random.default_rng(0)
+    hi = max(2, len(tiles) - 1)
+    n = min(len(marks), hi - 1)
+    rand_inst: list[float] = []
+    rand_cov: list[float] = []
+    for _ in range(RANDOM_DRAWS):
+        r = np.sort(rng.choice(np.arange(1, hi), n, replace=False)).astype(float)
+        rand_inst.append(np.mean([instability(ti, x) for x in r]))
+        rand_cov.append(coverage(ti, r, r))
+
+    res: dict[str, Any] = {
+        "video": name,
+        "duration_s": round(len(tiles) / args.fps, 1),
+        "frames": len(tiles),
+        "decode_s": round(decode_s, 1),
+        "realtime_x": round((len(tiles) / args.fps) / decode_s, 1),
+        "marks": len(marks),
+        "median_score": int(np.median(scores)),
+        "instability": {
+            "at_t": round(at_t, 4),
+            "at_look": round(at_look, 4),
+            "random": round(float(np.mean(rand_inst)), 4),
+            "look_vs_t": round(at_t / at_look, 2) if at_look else None,
+        },
+        "coverage": {
+            "at_t": round(cov_t, 4),
+            "at_look": round(cov_look, 4),
+            "random_mean": round(float(np.mean(rand_cov)), 4),
+            "random_std": round(float(np.std(rand_cov)), 4),
+            "sigma_above_random": (
+                round((cov_look - float(np.mean(rand_cov))) / float(np.std(rand_cov)), 1)
+                if np.std(rand_cov) > 0 else None
+            ),
+        },
+    }
+    print(json.dumps(res, indent=1))
+    if args.json:
+        with Path(args.json).open("a") as fh:
+            fh.write(json.dumps(res) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/sweep.sh
+++ b/scratch/sweep.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Run the mark evaluation over every recording available on this machine.
+set -u
+cd /Users/moiz/Documents/code/deixis
+OUT=scratch/eval/mark_eval.jsonl
+for v in "/Users/moiz/Movies/2024-11-14 17-21-27.mkv" \
+         "/Users/moiz/Movies/2024-11-14 17-23-06.mkv" \
+         "/Users/moiz/Movies/2024-11-14 17-23-57.mkv" \
+         "/Users/moiz/Movies/2024-11-14 17-33-37.mkv" \
+         "/Users/moiz/Movies/2024-11-14 17-26-56.mkv" \
+         "/Users/moiz/Documents/code/hack-pearl/Screen Recording 2026-06-06 at 22.19.45.mov" \
+         "/Users/moiz/Desktop/Screen Recording 2026-08-06 at 15.07.10.mov" \
+         "/Users/moiz/Desktop/Screen Recording 2026-07-31 at 09.35.23.mov"; do
+  echo "### $(basename "$v")"
+  uv run python scratch/mark_eval.py "$v" --json "$OUT" || echo "FAILED: $v"
+done
+echo "### sweep complete"


### PR DESCRIPTION
Every number this project had came from **one 33-minute recording on one laptop**. This is the n=1 check.

## 1. Eight local recordings

`scratch/mark_eval.py` scores the shipped code on any video against a random baseline — no ground truth needed, both metrics come from the video's own pixels. Two resolutions, 16 seconds to 74 minutes.

| | result |
|---|---|
| `look` more stable than the mark itself | **8 / 8** (1.8× – 7.2×) |
| `look` beats random on coverage | **8 / 8** (0.8 – 18.8 σ) |
| `look` beats random on *instability* | **4 / 8** ← does **not** generalise |

That last row is in the doc, not buried. On short high-motion clips a random frame is often *calmer* than a `look` frame — marks cluster where the action is, random spreads into the dead air. Random gets you a calmer frame; `look` gets you a frame that **represents the second you asked about**. Only the second is what enumeration needs.

## 2. GUI-World — external ground truth

[GUI-World](https://huggingface.co/datasets/shuaishuaicdp/GUI-World) (ICLR 2025, CC BY 4.0): 496 desktop recordings with keyframes placed by **human annotators** at the moments a user action changed the screen. Budget set to exactly the human keyframe count per video; baseline is 200 draws of the same number of uniform timestamps.

```
39 videos, mean distance from a human keyframe to the nearest mark
    ours    0.79s
    random  1.36s
ours closer on 37 / 38 videos     one-sided sign test  p < 0.0001
```

**This is the strongest evidence the detector has** — third-party data, human labels, decisive margin.

### It does not contradict the earlier "worse than random" finding

| Target | Nature | Marks |
|---|---|---|
| GUI-World keyframes | user acted, screen changed — **transitions** | **win, p < 0.0001** |
| Deictic sentences | speaker explains what's already up — **plateaus** | **lose to random** |

A change detector finds changes. Explanation happens *after* the change, while the screen sits still. Both results are correct; together they say exactly what the marks are for.

## 3. 1 fps is the best setting, not a compromise

```
fps=1  ours 0.79s vs random 1.36s   37/38   p < 0.0001
fps=2  ours 0.84s vs random 1.31s   34/39   p < 0.0001
fps=4  ours 1.00s vs random 1.31s   30/39   p = 0.0005
fps=8  ours 1.11s vs random 1.31s   28/39   p = 0.0047
```

Monotonic degradation as sampling gets finer. The first version of the harness defaulted to 4 fps and argued in its docstring that 1 fps would be too coarse for 15-second clips — confident, written before measuring, and wrong. Corrected in place with the numbers.

## Housekeeping

One of the 40 downloaded videos is truncated on the hub; it is **skipped and named** in the output, never silently dropped. `docs/datasets-surveyed.md` records the dataset search including the eight candidates rejected and why each fails.

No production code changed. `just check` green: 187 passed.