### PR TITLE
feat: a deixis command, so frame retrieval is reachable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
             exit 1
           fi
           passed=$(grep -oE '[0-9]+ passed' /tmp/summary | grep -oE '^[0-9]+')
-          if [ "${passed:-0}" -lt 187 ]; then
-            echo "::error::fast lane is ${passed:-no} passed, floor is 187 -- the suite shrank"
+          if [ "${passed:-0}" -lt 198 ]; then
+            echo "::error::fast lane is ${passed:-no} passed, floor is 198 -- the suite shrank"
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ in the meeting and, as text, it is worthless. The referent was on screen.
 |---|---|
 | **Transcript half** | working — ingestion, chunked ASR, resume, optional speaker labels |
 | **Visual marks** | working — the moments the picture changed. [Validated externally](docs/generalisation.md) against human annotations (p < 0.0001), but [worth little on their own](docs/do-marks-help.md) for answering questions |
-| **Frame retrieval** | working — `media.extract_frame(video, t, dest)`. This is what actually makes a recording answerable: 5/16 → 16/16 on a blind-graded question set |
+| **Frame retrieval** | working — `deixis frame video 431.5 -o f.jpg`. This is what actually makes a recording answerable: 5/16 → 16/16 on a blind-graded question set |
 | **Frame description** | **not built**, and now blocked on a *measured* finding rather than an unmeasured one. See [Roadmap](#roadmap) |
 
 So today deixis is a resumable, observable transcriber that also tells you
@@ -56,8 +56,32 @@ Model weights (~2.4 GB) download on first run and are cached by
 
 ## Usage
 
+One command, three verbs:
+
 ```bash
-uv run python -m deixis.transcribe recording.mov -o transcript.json
+deixis transcribe recording.mov -o transcript.json   # what was said, when
+deixis mark       recording.mov -t transcript.json   # when the picture changed
+deixis frame      recording.mov 431.5 -o frame.jpg   # the picture at that moment
+```
+
+`deixis frame` prints the path it wrote and nothing else, so it composes:
+
+```bash
+open "$(deixis frame recording.mov 431.5 -o /tmp/f.jpg)"
+```
+
+**If you point an agent at a recording, tell it about `deixis frame`.** That one
+verb is the difference between an agent reconstructing the screen from what was
+said about it and an agent looking: measured 5/16 against 16/16 on a
+blind-graded question set ([docs/do-marks-help.md](docs/do-marks-help.md)).
+
+`python -m deixis.transcribe` and `python -m deixis.frames` still work and are
+the same code.
+
+### Transcription
+
+```bash
+deixis transcribe recording.mov -o transcript.json
 ```
 
 Progress renders live on stderr:
@@ -117,18 +141,22 @@ failed. [docs/visual-marks.md](docs/visual-marks.md) has the numbers.
 
 ### Retrieving a frame
 
-```python
-from pathlib import Path
-from deixis.media import extract_frame
-
-extract_frame(Path("recording.mov"), 431.5, Path("frame.jpg"), width=1500)
+```bash
+deixis frame recording.mov 431.5 -o frame.jpg [--width 1500]
 ```
 
-Nothing is precomputed and nothing is cached — the video is already on disk.
-This is the step that makes the index worth having: on a blind-graded set of
-eight questions drawn from the transcript's deictic sentences, an agent with the
-transcript alone scored 5/16, with marks added 7/16, and with frame access
-**16/16**. [docs/do-marks-help.md](docs/do-marks-help.md) has the method.
+| Flag | |
+|---|---|
+| `-o, --out PATH` | where the image goes; `.jpg` is what a vision model wants |
+| `--width N` | scale to N pixels wide, aspect preserved (default 1500; `0` keeps source) |
+
+Nothing is precomputed and nothing is cached — the video is already on disk, and
+seeking into it is cheap. The 1500px default is a measured ceiling rather than a
+taste: a full 2940px frame is ~776 KB as a JPEG, more than most vision APIs
+want, and legibility stopped improving well below that — 700px to 1600px moved
+recall by one string in fifteen ([docs/vlm-legibility.md](docs/vlm-legibility.md)).
+
+Also available as `deixis.media.extract_frame(video, t, dest, width=...)`.
 
 ## Output
 
@@ -414,6 +442,7 @@ are OCR-based, which is the approach this tool rejects.
 deixis/            the package
   media.py         ffmpeg ingestion, with progress and actionable errors
   transcribe.py    the CLI and the orchestration
+  cli.py           the `deixis` command: transcribe | mark | frame
   frames.py        the moments the picture changed, ranked under a budget
   chunking.py      the chunk loop parakeet-mlx does not provide
   checkpoint.py    resume, and the validated boundary that reads it

--- a/deixis/cli.py
+++ b/deixis/cli.py
@@ -1,0 +1,102 @@
+"""One command, three verbs -- the surface an agent actually reaches for.
+
+Until this file existed, the only way to pull a frame out of a video was to
+import `deixis.media` from Python. That is a real gap and not a cosmetic one:
+frame retrieval is the step measured to take an agent from 5/16 to 16/16 on
+questions about a recording (docs/do-marks-help.md), and the agent that scored
+16/16 only managed it because a `uv run python -c ...` snippet was hand-written
+into its prompt. A capability nothing can invoke is a capability nobody has.
+
+    deixis transcribe recording.mov -o transcript.json
+    deixis mark       recording.mov -t transcript.json
+    deixis frame      recording.mov 431.5 -o frame.jpg
+
+`transcribe` and `mark` delegate to the module CLIs that already existed, so
+`python -m deixis.transcribe` and `python -m deixis.frames` keep working exactly
+as before and there is one implementation of each, not two.
+
+`frame` prints the path it wrote to stdout and nothing else. That is deliberate:
+the caller is usually a program, and a path on stdout composes.
+"""
+
+from __future__ import annotations
+
+__all__ = ["main"]
+
+import argparse
+import sys
+from pathlib import Path
+
+USAGE = """deixis <command> [options]
+
+  transcribe VIDEO -o OUT.json      what was said, when
+  mark       VIDEO -t TRANSCRIPT    when the picture changed
+  frame      VIDEO SECONDS -o IMG   the picture at that moment
+
+Run `deixis <command> --help` for the options of one command."""
+
+
+def _frame(argv: list[str]) -> int:
+    """Write one frame to a file and print where it went."""
+    from deixis.media import extract_frame
+
+    ap = argparse.ArgumentParser(
+        prog="deixis frame",
+        description="Write the frame at a given second of a video to an image file.",
+    )
+    ap.add_argument("video", type=Path)
+    ap.add_argument("seconds", type=float, help="offset into the recording")
+    ap.add_argument("-o", "--out", type=Path, required=True, help=".jpg for a vision model")
+    ap.add_argument(
+        "--width",
+        type=int,
+        # 1500px is not a default so much as a measured ceiling: on the
+        # reference recording a full 2940px frame is ~776 KB as a JPEG, over
+        # what most vision APIs want, and legibility stopped improving well
+        # before that (docs/vlm-legibility.md -- 700 -> 1600px moved recall by
+        # one string out of fifteen). None keeps the source resolution.
+        default=1500,
+        help="scale to this width, preserving aspect (default 1500; 0 keeps source)",
+    )
+    args = ap.parse_args(argv)
+
+    dest = extract_frame(
+        args.video, args.seconds, args.out, width=args.width or None
+    )
+    print(dest)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch to a subcommand.
+
+    Returns:
+        A process exit code -- 2 for an unknown or missing command, otherwise
+        whatever the subcommand returns.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+    if not args or args[0] in ("-h", "--help", "help"):
+        print(USAGE)
+        # 0 for an explicit --help, 2 for a bare invocation: a caller that
+        # forgot the verb has made an error, and a shell script testing the
+        # exit code should see one.
+        return 0 if args else 2
+
+    command, rest = args[0], args[1:]
+    if command == "frame":
+        return _frame(rest)
+    if command == "transcribe":
+        from deixis.transcribe import main as transcribe_main
+
+        return transcribe_main(rest)
+    if command == "mark":
+        from deixis.frames import main as frames_main
+
+        return frames_main(rest)
+
+    print(f"deixis: unknown command {command!r}\n\n{USAGE}", file=sys.stderr)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,13 @@ dependencies = [
     "pydantic>=2.13.4",
 ]
 
+# The reachable surface. Until this existed, pulling a frame out of a video
+# meant importing deixis.media from Python -- and frame retrieval is the step
+# measured to take an agent from 5/16 to 16/16 (docs/do-marks-help.md). A
+# capability nothing can invoke is a capability nobody has.
+[project.scripts]
+deixis = "deixis.cli:main"
+
 [project.optional-dependencies]
 diarize = [
     "senko>=0.1.0,<0.2",

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -1,0 +1,175 @@
+"""The `deixis` command: does each verb reach the thing it names?
+
+Small surface, but the one that decides whether any of this is usable. The
+measurement that justifies frame retrieval (docs/do-marks-help.md) was only
+possible because a Python snippet was hand-written into an agent's prompt; these
+tests exist so the supported path cannot quietly stop working.
+
+The dispatch tests assert ROUTING, not behaviour -- transcribe and mark are
+covered by their own suites, and re-running real ASR here would buy nothing for
+two minutes of wall clock.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from deixis.cli import main
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None,
+    reason="ffmpeg/ffprobe not on PATH",
+)
+
+
+@pytest.fixture
+def video(tmp_path: Path) -> Path:
+    """Two colours, 4 seconds each, so a seek can be checked for landing right."""
+    parts: list[Path] = []
+    for i, colour in enumerate(("0x101010", "0xE0E0E0")):
+        part = tmp_path / f"p{i}.mp4"
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-f", "lavfi",
+             "-i", f"color=c={colour}:s=320x240:d=4:r=10", "-pix_fmt", "yuv420p", str(part)],
+            check=True,
+        )
+        parts.append(part)
+    listing = tmp_path / "parts.txt"
+    listing.write_text("".join(f"file '{p}'\n" for p in parts))
+    dest = tmp_path / "v.mp4"
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-f", "concat", "-safe", "0",
+         "-i", str(listing), "-c", "copy", str(dest)],
+        check=True,
+    )
+    return dest
+
+
+def _dimensions(image: Path) -> tuple[int, int]:
+    out = subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=width,height", "-of", "csv=p=0:s=x", str(image)],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    w, h = out.split("x")
+    return int(w), int(h)
+
+
+def _mean_grey(image: Path) -> float:
+    out = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(image),
+         "-vf", "scale=4:4,format=gray", "-f", "rawvideo", "-"],
+        capture_output=True, check=True,
+    ).stdout
+    return sum(out) / len(out)
+
+
+def test_a_bare_invocation_explains_itself_and_fails() -> None:
+    """Exit 2, not 0.
+
+    Forgetting the verb is a caller error, and a shell script checking the exit
+    code should be told about it.
+    """
+    assert main([]) == 2
+
+
+def test_help_is_not_an_error() -> None:
+    assert main(["--help"]) == 0
+    assert main(["help"]) == 0
+
+
+def test_an_unknown_verb_is_rejected(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["wat"]) == 2
+    assert "unknown command" in capsys.readouterr().err
+
+
+def test_frame_writes_the_image_and_prints_its_path(
+    video: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dest = tmp_path / "f.jpg"
+    assert main(["frame", str(video), "1.0", "-o", str(dest)]) == 0
+    assert dest.exists()
+    # The path alone on stdout, so a caller can use it directly.
+    assert capsys.readouterr().out.strip() == str(dest)
+
+
+def test_frame_seeks_to_the_second_asked_for(video: Path, tmp_path: Path) -> None:
+    """The fixture is near-black for 0-4s and near-white after.
+
+    A seek that landed in the wrong half is invisible to "a file was written".
+    """
+    early = tmp_path / "early.png"
+    late = tmp_path / "late.png"
+    main(["frame", str(video), "1.0", "-o", str(early)])
+    main(["frame", str(video), "6.0", "-o", str(late)])
+    assert _mean_grey(early) < 64 < 192 < _mean_grey(late)
+
+
+def test_frame_scales_to_the_requested_width(video: Path, tmp_path: Path) -> None:
+    """Aspect preserved, height even.
+
+    `scale=W:-2`, not `-1`: the latter can produce an odd height that some
+    encoders refuse outright.
+    """
+    dest = tmp_path / "f.jpg"
+    main(["frame", str(video), "1.0", "-o", str(dest), "--width", "160"])
+    assert _dimensions(dest) == (160, 120)
+
+
+def test_width_zero_keeps_the_source_resolution(video: Path, tmp_path: Path) -> None:
+    dest = tmp_path / "f.jpg"
+    main(["frame", str(video), "1.0", "-o", str(dest), "--width", "0"])
+    assert _dimensions(dest) == (320, 240)
+
+
+def test_a_bad_timestamp_surfaces_rather_than_writing_nothing(
+    video: Path, tmp_path: Path
+) -> None:
+    from deixis.media import MediaError
+
+    with pytest.raises(MediaError, match="past the end"):
+        main(["frame", str(video), "9999", "-o", str(tmp_path / "f.jpg")])
+
+
+def test_mark_routes_to_the_frames_cli(
+    video: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    seen: list[list[str]] = []
+
+    def fake(argv: list[str] | None = None) -> int:
+        seen.append(list(argv or []))
+        return 0
+
+    monkeypatch.setattr("deixis.frames.main", fake)
+    assert main(["mark", str(video), "-t", "t.json"]) == 0
+    assert seen == [[str(video), "-t", "t.json"]]
+
+
+def test_transcribe_routes_to_the_transcribe_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+
+    def fake(argv: list[str] | None = None) -> int:
+        seen.append(list(argv or []))
+        return 0
+
+    monkeypatch.setattr("deixis.transcribe.main", fake)
+    assert main(["transcribe", "v.mov", "-o", "out.json"]) == 0
+    assert seen == [["v.mov", "-o", "out.json"]]
+
+
+def test_the_installed_console_script_works() -> None:
+    """The entry point itself, not just the function behind it.
+
+    A `[project.scripts]` typo is invisible to every test that imports main()
+    directly -- and the console script is the whole point of this file.
+    """
+    proc = subprocess.run(
+        ["uv", "run", "deixis", "--help"], capture_output=True, text=True, check=False,
+        cwd=Path(__file__).resolve().parent.parent,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "frame      VIDEO SECONDS" in proc.stdout


### PR DESCRIPTION
```bash
deixis transcribe recording.mov -o transcript.json   # what was said, when
deixis mark       recording.mov -t transcript.json   # when the picture changed
deixis frame      recording.mov 431.5 -o frame.jpg   # the picture at that moment
```

## Why this was the priority

Until now, pulling a frame out of a video meant importing `deixis.media` from Python. That was the gap that mattered most: frame retrieval is the step measured to take an agent from **5/16 to 16/16**, and the agent that scored 16/16 only managed it because a `uv run python -c ...` snippet was hand-written into its prompt.

A capability nothing can invoke is a capability nobody has. 390 lines of mark detection shipped before the 68 lines that carried the result — the wrong order, and this closes it.

## Design

`transcribe` and `mark` **delegate** to the module CLIs that already existed, so `python -m deixis.transcribe` and `python -m deixis.frames` keep working and there is one implementation of each rather than two.

`frame` prints the path it wrote and nothing else, so it composes:

```bash
open "$(deixis frame recording.mov 431.5 -o /tmp/f.jpg)"
```

`--width` defaults to **1500** — a measured ceiling, not a taste. A full 2940px frame is ~776 KB as a JPEG, over what most vision APIs accept, and legibility stopped improving well below it: 700px → 1600px moved recall by one string in fifteen (`docs/vlm-legibility.md`). `--width 0` keeps source resolution.

A bare invocation prints usage and exits **2**, not 0 — forgetting the verb is a caller error and a script checking the exit code should be told. An explicit `--help` exits 0.

## Verification

11 tests, including one that runs the **installed console script in a subprocess** — a `[project.scripts]` typo is invisible to every test that imports `main()` directly, and the console script is the entire point.

Six mutants against the dispatch, all killed:

| Mutant | |
|---|---|
| bare invocation returns 0 | killed |
| unknown verb returns 0 | killed |
| `frame` ignores `--width` | killed |
| `frame` prints nothing | killed |
| `mark` loses its args | killed |
| `frame` verb never matches | killed |

Also verified by hand on the reference recording: `t=431.5` returns macOS Mission Control — which independently confirms the earlier finding that the highest-scoring mark in that file is a window-switcher animation with no content.

`just check` green: **198 passed**, pyright strict clean, ruff clean. CI floor 187 → 198.