### PR TITLE
test: 834 third-party recordings and five hour-long lectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ in the meeting and, as text, it is worthless. The referent was on screen.
 | | |
 |---|---|
 | **Transcript half** | working — ingestion, chunked ASR, resume, optional speaker labels |
-| **Visual marks** | working — the moments the picture changed. [Validated externally](docs/generalisation.md) against human annotations (p < 0.0001), but [worth little on their own](docs/do-marks-help.md) for answering questions |
+| **Visual marks** | working — the moments the picture changed. [Validated on 834 third-party recordings and five hour-long lectures](docs/generalisation.md), but [worth little on their own](docs/do-marks-help.md) for answering questions |
 | **Frame retrieval** | working — `deixis frame video 431.5 -o f.jpg`. This is what actually makes a recording answerable: 5/16 → 16/16 on a blind-graded question set |
 | **Frame description** | **not built**, and now blocked on a *measured* finding rather than an unmeasured one. See [Roadmap](#roadmap) |
 
@@ -226,7 +226,7 @@ can fail. That cost is the point — see [docs/tooling-gaps.md](docs/tooling-gap
 | [docs/resume-gate-design.md](docs/resume-gate-design.md) | how you test a resume that silently restarts, given it produces byte-identical output |
 | [docs/mutmut-triage.md](docs/mutmut-triage.md) | every surviving mutant and why it is accepted |
 | [docs/visual-marks.md](docs/visual-marks.md) | the three change detectors that were built and measured before this one, and why each failed |
-| [docs/generalisation.md](docs/generalisation.md) | eight more recordings plus GUI-World, the external benchmark: marks match human change annotations at p < 0.0001 |
+| [docs/generalisation.md](docs/generalisation.md) | two external benchmarks with human ground truth — 834 GUI recordings (p = 3.5e-94) and five hour-long lectures (81% of slide changes caught within 2s) |
 | [docs/do-marks-help.md](docs/do-marks-help.md) | do the marks actually help an agent? Three arms, blind-graded: 5/16 → 7/16 → 16/16 |
 | [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Measured: not this one |
 

--- a/docs/generalisation.md
+++ b/docs/generalisation.md
@@ -4,9 +4,9 @@ Every number in [visual-marks.md](visual-marks.md) and
 [do-marks-help.md](do-marks-help.md) came from one 33-minute Microsoft Teams
 recording on one laptop. That is n=1, and n=1 is a demo. This is the check.
 
-Three experiments: eight local recordings, an external benchmark with human
-ground truth, and a sampling-rate sweep. Two of the three changed what the
-project believes.
+Four experiments: eight local recordings, two external benchmarks with human
+ground truth (834 short GUI clips and five hour-long lectures), and a
+sampling-rate sweep. Three of the four changed what the project believes.
 
 ## 1. Eight local recordings — does the `look` idea generalise?
 
@@ -50,30 +50,33 @@ result. Random gets you a calmer frame; `look` gets you a frame that *represents
 the second you asked about*. For enumerating a recording the second is what
 matters, and `look` wins that 8/8.
 
-## 2. GUI-World — an external benchmark with human ground truth
+## 2. GUI-World — 834 recordings with human-annotated keyframes
 
 [GUI-World](https://huggingface.co/datasets/shuaishuaicdp/GUI-World) (ICLR 2025,
-CC BY 4.0) is 496 desktop screen recordings whose **keyframes were placed by
-human annotators** at the moments a user action changed the screen. Nobody here
-produced that ground truth, which is the entire point of using it.
+CC BY 4.0) is 496 desktop, 246 browser and 146 multi-app screen recordings whose
+**keyframes were placed by human annotators** at the moments a user action
+changed the screen. Nobody here produced that ground truth, which is the point.
 
-Method: 40 videos from the `software` benchmark split (one, `software/165.mp4`,
-is truncated on the hub and is skipped and named rather than silently dropped).
 For each video the budget is set to **exactly the number of human keyframes**,
-so the comparison is like-for-like, and the baseline is 200 draws of the same
-number of uniformly random timestamps.
+so the comparison is like-for-like rather than "who emits more guesses", and the
+baseline is 200 draws of the same number of uniformly random timestamps.
 
 ```
-39 videos scored
-mean distance from a human keyframe to the nearest mark
-    ours    0.79s
-    random  1.36s
-ours closer on 37 / 38 videos          one-sided sign test  p < 0.0001
+split       videos    ours   random   better       won          p
+software       490   1.18s    1.77s      33%   423/490    1.6e-64
+website        246   0.98s    1.31s      25%   202/246    1.1e-25
+multi           98   2.60s    2.84s       8%    76/98     1.9e-08
+TOTAL          834                             701/834    3.5e-94
 ```
 
-**The marks find human-annotated change moments, and they beat chance
-decisively.** This is an external, repeatable result on data from another
-research group, and it is the strongest evidence the detector has.
+Four `software` videos are truncated on the hub and 48 `multi` videos went
+unfetched at the download cap; both are named in the run output rather than
+quietly dropped.
+
+**The `multi` split is the honest weak spot** — 8% better than random, against
+33% on `software`. Those clips are the longest (27s median) with the most
+annotated changes, so a fixed budget of marks crowds together and the margin
+compresses.
 
 ### Why this does not contradict the deictic result
 
@@ -83,12 +86,70 @@ are correct and they measure different targets:
 
 | Target | Nature | Marks |
 |---|---|---|
-| GUI-World keyframes | *user acted, the screen changed* — transitions | **win, p < 0.0001** |
+| GUI-World keyframes | *user acted, the screen changed* — transitions | **win, p = 3.5e-94** |
 | Deictic sentences | *speaker explains what is already on screen* — plateaus | **lose to random** |
 
 A change detector finds changes. It does not find explanations, and explanation
-happens after the change, while the screen sits still. Neither result is a bug;
-together they say precisely what the marks are for.
+happens after the change, while the screen sits still.
+
+## 2b. MaViLS — the long-form case, 34 to 85 minutes
+
+GUI-World clips are 15 seconds. deixis is for hour-long recordings, and that
+shape had no ground truth until now. [MaViLS](https://github.com/andererka/mavils)
+(Interspeech 2024) is 24 lectures whose transcribed sentences were mapped to
+slide numbers by human raters; five of them are public YouTube videos.
+
+**Ground truth here is an INTERVAL, not an instant.** A slide change is only
+localised between the last sentence on the old slide and the first on the new
+one. Scoring against either endpoint would invent precision the labels do not
+have, so a mark inside the interval scores 0 and outside scores the distance to
+the nearer end — and the random baseline is scored identically, so neither side
+profits from the slack. The derivation was checked by eye before use: the frames
+either side of one interval in `computer_vision_2_2` are a Camera Obscura
+engraving and two photographs, a real content change correctly bracketed.
+
+At a like-for-like budget (one mark per annotated change):
+
+```
+lecture                min    gt   marks    ours   random   hit%   rnd%
+computer_vision_2_2   34.8    14      14   24.22    64.78    79%    21%
+deeplearning          54.3    51      51    9.08    28.40    76%    17%
+numerics              85.2    73      73    2.87    30.82    85%    16%
+psychology            71.2    55      55   16.67    35.87    47%    13%
+solar_resource        75.2    90      90   37.80    21.41    29%    20%
+
+mean distance   ours 18.13s   random 36.26s
+within 2s       ours 63%      random 17%      ours closer on 4/5
+```
+
+At the **shipped default** budget of 150 marks — what a user actually gets:
+
+```
+mean distance   ours 5.15s    random 9.26s
+within 2s       ours 81%      random 42%      ours closer on 4/5
+```
+
+**Four in five slide changes are caught within two seconds on an hour-long
+lecture.** That is the first evidence for the workload this project exists for.
+
+### The one lecture it fails, and why
+
+`solar_resource` loses to random in both modes. The cause is visible in a single
+frame: it is **a camera pointed at a lecture hall**, not a screen recording. A
+presenter walks about in front of a projected slide, and his motion dominates
+every frame. Measured against a true screen capture:
+
+```
+median per-second change score
+  solar_resource   2187      <- camera in the room, presenter moving
+  numerics          347      <- screen capture
+```
+
+Six times the noise floor, and the slide changes are buried under it. This is a
+real limit worth stating plainly: **the detector assumes the frame IS the
+screen.** Neither the budget nor any threshold rescues a recording where most of
+the pixels are a person. Detecting that case — the score's own noise floor is
+the obvious signal — is not implemented.
 
 ## 3. The sampling rate — 1 fps is the best setting, not a compromise
 
@@ -116,24 +177,39 @@ moment; coarse sampling forces them apart.
 **Established:**
 
 - The `look` midpoint beats the mark itself on every video tried (8/8).
-- Marks match human change annotations far better than chance on an external,
-  third-party benchmark (p < 0.0001, 39 videos).
+- Marks match human change annotations far better than chance on **834
+  third-party GUI recordings**, p = 3.5e-94 pooled.
+- On **hour-long lectures with slide-change ground truth**, 81% of changes are
+  caught within two seconds at the shipped default budget, against 42% for
+  random. This is the workload the project targets and it now has evidence.
 - 1 fps is the right default, on evidence rather than convenience.
-- The pipeline runs unmodified on 1920x1080 OBS captures and 2940x1912 macOS
-  captures, on clips from 16 seconds to 74 minutes.
+- The pipeline runs unmodified from 16-second clips to 85-minute lectures, on
+  1920x1080 OBS captures, 2940x1912 macOS captures and YouTube lecture video.
 
-**Not established:**
+**Not established, and one known failure:**
 
-- GUI-World clips are short (median ~15s, dense actions). Long-form sparse
-  change is only tested on the two local Teams recordings.
-- The eight local videos have no ground truth; their metrics are self-supervised
-  and can only compare schemes, never confirm that a mark is *interesting*.
-- Nothing here re-tests whether marks help an *agent*. That measurement remains
-  the one in [do-marks-help.md](do-marks-help.md), n=8 questions, one recording.
-- No lecture, no coding session, no browser-only session.
+- **A camera pointed at a screen defeats it.** `solar_resource` is a lecture
+  hall filmed from the back; the presenter's motion is 6x the change floor of a
+  real screen capture and the slide changes vanish under it. Detecting this case
+  automatically is not implemented.
+- The `multi` GUI-World split wins by only 8%. Denser change compresses the
+  margin.
+- Five lectures is a small long-form sample, and all five are slide decks. No
+  coding session, no browser-only long-form session.
+- The eight local videos have no ground truth; their metrics can compare schemes
+  but never confirm a mark is *interesting*.
+- Nothing here re-tests whether marks help an *agent*. That remains
+  [do-marks-help.md](do-marks-help.md), n=8 questions, one recording.
 
-The closest complement for long-form ground truth is
-[MaViLS](https://github.com/andererka/mavils) — 20 lectures, ~66 minutes each,
-sentence-to-slide alignment — which needs a Kaggle account and gives boundaries
-only at sentence granularity. [datasets-surveyed.md](datasets-surveyed.md) records that survey,
-including the eight candidates that were checked and rejected.
+## Datasets that turned out unusable
+
+Checked by inspecting what actually landed on disk, not by reading a page:
+
+| Dataset | Why not |
+|---|---|
+| **SeeAction** | 2 GB fetched, and it is `dataset/Images/photoshop_001/03538.png` — extracted **frames**, not video. The archive is also truncated at exactly 2 GiB by the download cap. |
+| **VidChapters-7M** | 1.9 GB is `chapters.pkl` — annotations only. Every video needs a separate yt-dlp fetch, and screen content is an unlabelled minority of general YouTube. |
+| **PsTuts** | Google Drive download produced 0 bytes. |
+
+[datasets-surveyed.md](datasets-surveyed.md) records the wider survey, including
+eight further candidates rejected before download.

--- a/scratch/datasets/mavils_gt_to_changepoints.py
+++ b/scratch/datasets/mavils_gt_to_changepoints.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Turn MaViLS ground-truth spreadsheets into change-point timestamps in seconds.
+
+Each MaViLS ground-truth .xlsx has one row per transcribed sentence:
+
+    Time (or Key) | Slidenumber | Value
+    127.70        | 3           | "OK, so now that we've situated us, ..."
+
+`Time` is the sentence start in seconds from the beginning of the recording.
+`Slidenumber` is the slide the human rater says is on screen at that moment;
+-1 means "no slide visible" (camera on the speaker, whiteboard, demo).
+
+Needs pandas and openpyxl, which are NOT project dependencies -- nothing
+shipped reads spreadsheets. Run it without touching the lockfile:
+
+    uv run --with pandas --with openpyxl python \
+      scratch/datasets/mavils_gt_to_changepoints.py \
+      scratch/datasets/mavils/data/ground_truth_files -o mavils_changepoints.json
+
+Verified 2026-08-10: regenerates scratch/datasets/mavils_changepoints.json
+byte-identically -- 24 lectures, 25.2 h, 1344 change points.
+
+A change point is any row whose Slidenumber differs from the previous row's.
+The emitted timestamp is that row's Time -- i.e. the first sentence spoken
+under the new slide. The true pixel change happened somewhere in the silent
+gap before it, so each mark is a late-biased estimate; see `lower_bound`.
+
+Usage:
+    uv run --with pandas --with openpyxl python mavils_gt_to_changepoints.py \
+        mavils/data/ground_truth_files -o mavils_changepoints.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import pandas as pd
+
+
+def changepoints(path):
+    """Return (metadata, list-of-changepoint-dicts) for one ground-truth file."""
+    df = pd.read_excel(path)
+
+    # Some files name the time column "Time", others "Key". Same meaning.
+    time_col = "Time" if "Time" in df.columns else "Key"
+    if time_col not in df.columns or "Slidenumber" not in df.columns:
+        raise ValueError(f"{path}: unexpected columns {list(df.columns)}")
+
+    df = df.dropna(subset=[time_col, "Slidenumber"]).sort_values(time_col)
+    times = df[time_col].astype(float).tolist()
+    slides = df["Slidenumber"].astype(int).tolist()
+
+    points = []
+    for i in range(1, len(times)):
+        if slides[i] == slides[i - 1]:
+            continue
+        points.append(
+            {
+                "time": times[i],
+                # The change cannot have happened before the previous sentence
+                # started, so [lower_bound, time] brackets the true instant.
+                "lower_bound": times[i - 1],
+                "from_slide": slides[i - 1],
+                "to_slide": slides[i],
+                # A -1 endpoint means the view left or entered "no slide" --
+                # still a real visual change, but a cut rather than a slide flip.
+                "kind": "slide_flip" if -1 not in (slides[i - 1], slides[i]) else "view_cut",
+            }
+        )
+
+    meta = {
+        "file": Path(path).name,
+        "sentences": len(times),
+        "duration_s": times[-1] if times else 0.0,
+        "distinct_slides": len(set(slides)),
+        "n_changes": len(points),
+    }
+    return meta, points
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("gt_dir", help="directory of MaViLS ground_truth_*.xlsx files")
+    ap.add_argument("-o", "--out", default="mavils_changepoints.json")
+    args = ap.parse_args()
+
+    result = {}
+    for path in sorted(Path(args.gt_dir).glob("*.xlsx")):
+        meta, points = changepoints(path)
+        result[meta["file"]] = {"meta": meta, "changepoints": points}
+        flips = sum(p["kind"] == "slide_flip" for p in points)
+        print(
+            f"{meta['file'][:50]:50s} {meta['duration_s']/60:6.1f} min "
+            f"{meta['n_changes']:4d} changes ({flips} flips, "
+            f"{meta['n_changes']-flips} cuts)"
+        )
+
+    with open(args.out, "w") as fh:
+        json.dump(result, fh, indent=1)
+    total = sum(r["meta"]["n_changes"] for r in result.values())
+    hours = sum(r["meta"]["duration_s"] for r in result.values()) / 3600
+    print(f"\n{len(result)} lectures, {hours:.1f} h, {total} change points -> {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scratch/fetch_guiworld.py
+++ b/scratch/fetch_guiworld.py
@@ -1,0 +1,50 @@
+"""Fetch the GUI-World benchmark videos for the three desktop/browser splits.
+
+Mobile (android/IOS) and XR are skipped: different modality, and their
+annotations do not even use the same `keyframes` key.
+"""
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path("scratch/guiworld")
+SPLITS = ("software", "website", "multi")
+CAP_GB = 6.0
+
+def size_gb(p: Path) -> float:
+    return sum(f.stat().st_size for f in p.rglob("*.mp4")) / 1e9
+
+want: list[str] = []
+for split in SPLITS:
+    ann = ROOT / "Annotation/benchmark" / f"{split}.jsonl"
+    rows = [json.loads(line) for line in ann.open()]
+    for r in rows:
+        p = r["video_path"]
+        if not (ROOT / p).exists():
+            want.append(p)
+print(f"{len(want)} videos to fetch across {SPLITS}", flush=True)
+failed: list[str] = []
+
+BATCH = 40
+for i in range(0, len(want), BATCH):
+    if size_gb(ROOT) > CAP_GB:
+        print(f"CAP HIT at {size_gb(ROOT):.1f} GB -- stopping, {len(want)-i} videos left unfetched", flush=True)
+        break
+    chunk = want[i:i+BATCH]
+    # Retry, and COUNT what still failed. The first version passed check=False
+    # and printed only progress, so a transient hub error silently left 182 of
+    # 246 website videos unfetched and the run still said "done".
+    for _attempt in range(3):
+        subprocess.run(["hf","download","shuaishuaicdp/GUI-World",*chunk,
+                        "--repo-type","dataset","--local-dir",str(ROOT),"--quiet"], check=False)
+        if all((ROOT / c).exists() for c in chunk):
+            break
+    missing = [c for c in chunk if not (ROOT / c).exists()]
+    if missing:
+        failed.extend(missing)
+        print(f"  FAILED after 3 attempts: {len(missing)} of this batch", flush=True)
+    print(f"  {i+len(chunk)}/{len(want)}  {size_gb(ROOT):.2f} GB", flush=True)
+
+print(f"done {size_gb(ROOT):.2f} GB", flush=True)
+if failed:
+    print(f"UNFETCHED: {len(failed)} videos -- {failed[:10]}", flush=True)

--- a/scratch/guiworld_eval.py
+++ b/scratch/guiworld_eval.py
@@ -48,7 +48,10 @@ from deixis.frames import GRID_H, GRID_W, change_scores, select_marks
 from deixis.media import extract_tile_grid
 
 ROOT = Path(__file__).resolve().parent / "guiworld"
-ANN = ROOT / "Annotation" / "benchmark" / "software.jsonl"
+
+
+def annotations(split: str) -> Path:
+    return ROOT / "Annotation" / "benchmark" / f"{split}.jsonl"
 
 
 def video_fps(path: Path) -> float | None:
@@ -80,10 +83,12 @@ def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--fps", type=float, default=1.0)
     ap.add_argument("--limit", type=int, default=40)
+    ap.add_argument("--split", default="software", help="software | website | multi")
+    ap.add_argument("--quiet", action="store_true", help="totals only, no per-video rows")
     ap.add_argument("--draws", type=int, default=200)
     args = ap.parse_args()
 
-    rows = [json.loads(line) for line in ANN.open()]
+    rows = [json.loads(line) for line in annotations(args.split).open()]
     rng = np.random.default_rng(0)
     ours: list[float] = []
     rand: list[float] = []
@@ -133,8 +138,12 @@ def main() -> int:
         })
 
     o, r = np.array(ours), np.array(rand)
-    print(f"{'video':<18}{'app':<22}{'dur':>6}{'gt':>4}{'ours':>7}{'random':>8}  winner")
-    for v in per_video:
+    if not len(o):
+        print(f"{args.split}: no scorable videos on disk")
+        return 0
+    if not args.quiet:
+        print(f"{'video':<18}{'app':<22}{'dur':>6}{'gt':>4}{'ours':>7}{'random':>8}  winner")
+    for v in per_video if not args.quiet else []:
         w = "ours" if v["ours_s"] < v["random_s"] else "random"  # type: ignore[operator]
         print(f"{v['video']!s:<18}{str(v['app'])[:21]:<22}{v['duration_s']:>6}"
               f"{v['gt']:>4}{v['ours_s']:>7}{v['random_s']:>8}  {w}")
@@ -142,7 +151,8 @@ def main() -> int:
     wins = int((o < r).sum())
     if skipped:
         print(f"\nSKIPPED (unreadable file): {', '.join(skipped)}")
-    print(f"\nvideos scored            : {len(o)}")
+    print(f"\nsplit                    : {args.split}")
+    print(f"videos scored            : {len(o)}")
     print(f"mean distance to a human keyframe -- ours {o.mean():.2f}s  random {r.mean():.2f}s")
     print(f"ours closer on           : {wins}/{len(o)} videos")
     # Sign test: how surprising is that win count if the two were equivalent?
@@ -150,10 +160,10 @@ def main() -> int:
     n = len(o)
     p = sum(comb(n, k) for k in range(wins, n + 1)) / 2**n
     print(f"one-sided sign test      : p = {p:.4f}")
-    Path("scratch/eval/guiworld.json").write_text(
+    Path(f"scratch/eval/guiworld_{args.split}.json").write_text(
         json.dumps({"per_video": per_video, "wins": wins, "n": n,
                     "mean_ours": float(o.mean()), "mean_random": float(r.mean()),
-                    "p": p, "fps": args.fps}, indent=1)
+                    "p": p, "fps": args.fps, "split": args.split}, indent=1)
     )
     return 0
 

--- a/scratch/mavils_eval.py
+++ b/scratch/mavils_eval.py
@@ -1,0 +1,163 @@
+"""Score deixis' marks against MaViLS slide changes, on 22-102 minute lectures.
+
+The long-form benchmark. GUI-World validated the detector on 15-second GUI clips
+with dense action; this is the other end -- hour-long recordings where the
+screen is a slide deck and a change is rare. That shape is what deixis is
+actually for, and until now nothing with ground truth covered it.
+
+GROUND TRUTH IS AN INTERVAL, NOT AN INSTANT. MaViLS raters mapped each
+transcribed sentence to a slide number, so a slide change is only localised
+between the last sentence on the old slide (`lower_bound`) and the first
+sentence on the new one (`time`). Scoring against either endpoint alone would
+invent precision the labels do not have, so a mark landing anywhere inside the
+interval scores 0 and outside it scores the distance to the nearer end. The
+random baseline is scored identically, so neither side profits from the slack.
+
+Verified before trusting the derivation: the frames either side of one interval
+in computer_vision_2_2 are a Camera Obscura engraving and two photographs --
+a real content change, correctly bracketed.
+
+Usage: python scratch/mavils_eval.py [--budget-mode gt|default]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from deixis.frames import GRID_H, GRID_W, change_scores, select_marks
+from deixis.media import extract_tile_grid
+
+DATA = Path(__file__).resolve().parent / "datasets"
+GT = DATA / "mavils_changepoints.json"
+VIDEOS = DATA / "mavils_youtube"
+
+# The five lectures whose video was fetched, keyed to their ground-truth file.
+PAIRS = {
+    "computer_vision_2_2_high_res_NIaICLR7D0Q.mp4": "ground_truth_computer_vision_2_2.xlsx",
+    "deeplearning_goodfellow_XlYD8jn1ayE.mp4": "ground_truth_deeplearning.xlsx",
+    "numerics_hennig_2ETIOk_Sbhk.mp4": "ground_truth_numerics.xlsx",
+    "psychology_MIT_syXplPKQb_o.mp4": "ground_truth_psychology.xlsx",
+    "solar_resource_BcVzc6IGwS0.mp4": "ground_truth_solar_resource.xlsx",
+}
+
+TOLERANCE_S = 2.0  # a hit, at 1 fps sampling
+RANDOM_DRAWS = 100
+
+
+def interval_distance(marks: np.ndarray, lo: float, hi: float) -> float:
+    """Distance from the nearest mark to the interval [lo, hi]; 0 if inside."""
+    inside = (marks >= lo) & (marks <= hi)
+    if inside.any():
+        return 0.0
+    return float(np.minimum(np.abs(marks - lo), np.abs(marks - hi)).min())
+
+
+def score(marks: np.ndarray, intervals: list[tuple[float, float]]) -> tuple[float, float]:
+    """Mean distance to ground truth, and the fraction hit within TOLERANCE_S."""
+    d = np.array([interval_distance(marks, lo, hi) for lo, hi in intervals])
+    return float(d.mean()), float((d <= TOLERANCE_S).mean())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fps", type=float, default=1.0)
+    ap.add_argument("--min-gap", type=float, default=5.0)
+    ap.add_argument(
+        "--budget-mode",
+        default="gt",
+        choices=("gt", "default"),
+        help="gt: one mark per ground-truth change (like-for-like). "
+        "default: the shipped budget of 150, i.e. what a user actually gets.",
+    )
+    args = ap.parse_args()
+
+    truth = json.loads(GT.read_text())
+    rng = np.random.default_rng(0)
+    rows: list[dict[str, float | int | str]] = []
+
+    for video_name, gt_key in PAIRS.items():
+        path = VIDEOS / video_name
+        if not path.exists() or gt_key not in truth:
+            print(f"SKIP {video_name}: video or ground truth missing")
+            continue
+
+        t0 = time.monotonic()
+        tiles = extract_tile_grid(path, fps=args.fps, width=GRID_W, height=GRID_H)
+        decode_s = time.monotonic() - t0
+        duration = len(tiles) / args.fps
+
+        cps = truth[gt_key]["changepoints"]
+        intervals = [
+            (float(c["lower_bound"]), float(c["time"]))
+            for c in cps
+            if float(c["time"]) <= duration
+        ]
+        if len(intervals) < 5:
+            print(f"SKIP {video_name}: only {len(intervals)} usable changepoints")
+            continue
+
+        budget = len(intervals) if args.budget_mode == "gt" else 150
+        marks = select_marks(
+            change_scores(tiles), fps=args.fps, budget=budget, min_gap_s=args.min_gap
+        )
+        mine = np.array([m.t for m in marks])
+        ours_d, ours_hit = score(mine, intervals)
+
+        draws = [
+            score(np.sort(rng.uniform(0, duration, len(marks))), intervals)
+            for _ in range(RANDOM_DRAWS)
+        ]
+        rand_d = float(np.mean([d for d, _ in draws]))
+        rand_hit = float(np.mean([h for _, h in draws]))
+
+        rows.append({
+            "lecture": gt_key.replace("ground_truth_", "").replace(".xlsx", ""),
+            "minutes": round(duration / 60, 1),
+            "gt": len(intervals),
+            "marks": len(marks),
+            "decode_s": round(decode_s),
+            "ours_s": round(ours_d, 2),
+            "random_s": round(rand_d, 2),
+            "ours_hit": round(ours_hit, 3),
+            "random_hit": round(rand_hit, 3),
+        })
+        print(f"  scored {rows[-1]['lecture']}", flush=True)
+
+    if not rows:
+        print("nothing scored")
+        return 1
+
+    print(f"\nbudget mode: {args.budget_mode}   tolerance: {TOLERANCE_S}s   fps: {args.fps}\n")
+    print(f"{'lecture':<24}{'min':>6}{'gt':>5}{'marks':>7}{'ours':>8}{'random':>8}"
+          f"{'hit%':>7}{'rnd%':>7}")
+    for r in rows:
+        print(f"{str(r['lecture'])[:23]:<24}{r['minutes']:>6}{r['gt']:>5}{r['marks']:>7}"
+              f"{r['ours_s']:>8}{r['random_s']:>8}"
+              f"{100 * float(r['ours_hit']):>6.0f}%{100 * float(r['random_hit']):>6.0f}%")
+
+    o = np.array([float(r["ours_s"]) for r in rows])
+    rd = np.array([float(r["random_s"]) for r in rows])
+    oh = np.array([float(r["ours_hit"]) for r in rows])
+    rh = np.array([float(r["random_hit"]) for r in rows])
+    print(f"\nmean distance to a slide change: ours {o.mean():.2f}s   random {rd.mean():.2f}s")
+    print(f"within {TOLERANCE_S:.0f}s of a change:        ours {100 * oh.mean():.0f}%"
+          f"      random {100 * rh.mean():.0f}%")
+    print(f"ours closer on {int((o < rd).sum())}/{len(o)} lectures")
+
+    out = Path("scratch/eval") / f"mavils_{args.budget_mode}.json"
+    out.write_text(json.dumps({"rows": rows, "fps": args.fps,
+                               "budget_mode": args.budget_mode}, indent=1))
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scratch/run_guiworld.sh
+++ b/scratch/run_guiworld.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -u
+cd /Users/moiz/Documents/code/deixis
+for split in software website multi; do
+  echo "########## $split"
+  uv run python scratch/guiworld_eval.py --split "$split" --limit 999 --fps 1 --quiet
+done
+echo "########## complete"

--- a/scratch/run_mavils_after.sh
+++ b/scratch/run_mavils_after.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Sequenced, not concurrent: both jobs are decode-bound on the same few cores,
+# and running them together would halve each and teach us nothing.
+set -u
+cd /Users/moiz/Documents/code/deixis
+while pgrep -f guiworld_eval >/dev/null; do sleep 30; done
+echo "########## mavils, like-for-like budget"
+uv run python scratch/mavils_eval.py --budget-mode gt
+echo "########## mavils, the shipped default budget"
+uv run python scratch/mavils_eval.py --budget-mode default
+echo "########## mavils complete"


### PR DESCRIPTION
Two external benchmarks with human ground truth. Replaces an n=39 result and fills the long-form gap every previous number left open. **No production code changed.**

## GUI-World — 834 third-party recordings

Desktop, browser and multi-app screen recordings whose keyframes were placed by **human annotators**. Budget set to exactly the human keyframe count per video; baseline is 200 uniform draws.

    split       videos    ours   random   better       won          p
    software       490   1.18s    1.77s      33%   423/490    1.6e-64
    website        246   0.98s    1.31s      25%   202/246    1.1e-25
    multi           98   2.60s    2.84s       8%    76/98     1.9e-08
    TOTAL          834                             701/834    3.5e-94

`multi` is the weak spot at 8%, reported not buried: longest clips, most annotated changes, so a fixed budget crowds and the margin compresses.

## MaViLS — five lectures, 34 to 85 minutes

The long-form case, which had no ground truth until now. Human raters mapped transcribed sentences to slide numbers.

**Ground truth is an interval, not an instant.** A change is only localised between the last sentence on the old slide and the first on the new. A mark inside scores 0; outside, distance to the nearer edge. Random is scored identically, so neither side profits from the slack.

At the shipped budget of 150:

    mean distance   ours 5.15s   random 9.26s
    within 2s       ours 81%     random 42%     ours closer on 4/5

Four in five slide changes caught within two seconds of an hour-long lecture.

## The one failure, and its cause

`solar_resource` loses to random in both modes, and one frame explains it: the recording is **a camera pointed at a lecture hall**, not a screen capture. The presenter walks in front of the slide and his motion is six times the change floor of a real capture:

    median per-second change score
      solar_resource   2187      camera in the room, presenter moving
      numerics          347      screen capture

The detector assumes the frame IS the screen. No budget or threshold rescues a recording where most pixels are a person. Detecting that case is not implemented.

## Three datasets fetched and found unusable

Determined by inspecting what landed on disk, not by reading a page:

| Dataset | Why not |
|---|---|
| SeeAction | `dataset/Images/photoshop_001/03538.png` — extracted frames, not video; archive truncated at the download cap |
| VidChapters-7M | 1.9 GB of `chapters.pkl` — annotations only, no videos |
| PsTuts | Google Drive download produced 0 bytes |

## Verification of the ground truth itself

The MaViLS derivation was checked twice before being trusted: the frames either side of one interval are a Camera Obscura engraving and two photographs — a real content change, correctly bracketed — and the whole file **regenerates byte-identically** (24 lectures, 25.2 h, 1344 change points).

My own fetch script had this project's signature bug: `check=False` left 182 of 246 website videos unfetched while printing "done". It now retries three times and names what it could not get.

`just check` green: 199 passed.
