### PR TITLE
fix: three defects an adversarial review found and I reproduced

### DIFF
--- a/jaano/dekho.py
+++ b/jaano/dekho.py
@@ -49,6 +49,7 @@ __all__ = [
     "GRID_H",
     "GRID_W",
     "Mark",
+    "MarkError",
     "change_scores",
     "main",
     "mark_video",
@@ -60,7 +61,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import numpy as np
 
@@ -73,6 +74,10 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 type Payload = dict[str, Any]
+
+
+class MarkError(RuntimeError):
+    """The transcript handed to the mark pass is not one."""
 
 logger = logging.getLogger("jaano.dekho")
 
@@ -290,7 +295,20 @@ def mark_video(
     """
     if not transcript.exists():
         raise FileNotFoundError(transcript)
-    payload: Payload = json.loads(transcript.read_text())
+    # Validated here because this is where the type stops being true: json.loads
+    # returns Any, and annotating it `Payload` does not make it a dict. A
+    # transcript that is a JSON ARRAY reaches with_marks and `dict()` accepts it
+    # -- an iterable of pairs -- because each object iterates as its keys. So
+    # [{"start": 0, "text": "hi"}] silently becomes {"start": "text"} and gets
+    # written back over the user's file. Destroying the input is the worst thing
+    # this tool could do; the guard costs one isinstance.
+    loaded: Any = json.loads(transcript.read_text())
+    if not isinstance(loaded, dict):
+        raise MarkError(
+            f"{transcript} is not a transcript: expected a JSON object, found "
+            f"{type(loaded).__name__}. Pass the file `jaano suno` wrote."
+        )
+    payload: Payload = cast("Payload", loaded)
 
     tiles = media_mod.extract_tile_grid(
         media, fps=fps, width=GRID_W, height=GRID_H, on_progress=on_progress

--- a/jaano/media.py
+++ b/jaano/media.py
@@ -248,6 +248,11 @@ def has_video(media: Path) -> bool:
     return bool(info.get("streams"))
 
 
+# How far before the target the coarse seek lands, in seconds. Big enough to
+# clear a long GOP, small enough that the exact decode after it stays cheap.
+PREROLL_S = 5.0
+
+
 def _duration(media: Path) -> float | None:
     """Seconds of video, or None if ffprobe will not say.
 
@@ -311,12 +316,32 @@ def extract_frame(media: Path, t: float, dest: Path, *, width: int | None = None
         )
 
     def _run(fast: bool) -> subprocess.CompletedProcess[str]:
-        # -ss BEFORE -i is the fast form: ffmpeg seeks the container rather than
-        # decoding from zero, which on a 33-minute file is milliseconds against
-        # half a minute. It is frame-accurate for containers carrying an index.
-        # -ss AFTER -i decodes forward from the start: slow, but it works on
-        # containers where the fast form finds nothing.
-        seek = ["-ss", str(t), "-i", str(media)] if fast else ["-i", str(media), "-ss", str(t)]
+        # THE SEEK, and why it is two -ss options rather than one.
+        #
+        # -ss BEFORE -i seeks the container instead of decoding from zero: on a
+        # 33-minute file that is milliseconds against half a minute. But on a
+        # container with no reliable index it either finds nothing (raw h264,
+        # long-GOP MPEG-TS) or -- worse -- snaps to the next keyframe and
+        # returns a frame from the WRONG MOMENT with exit 0 and no warning.
+        # Measured on an MPEG-TS at t=8s: the fast form returned the picture
+        # from t=9. For a tool whose entire promise is "the frame at this
+        # timestamp", silently late is the same class of failure as silently
+        # wrong.
+        #
+        # -ss AFTER -i decodes forward and is exact, but from zero.
+        #
+        # So: coarse-seek to PREROLL seconds early, then decode the remainder
+        # exactly. Bounded work (at most PREROLL seconds of decode) at any depth
+        # into the file, and accurate. Verified against a brightness ramp on an
+        # MPEG-TS -- all ten whole seconds matched a full accurate decode, where
+        # the fast form drifted.
+        if fast:
+            coarse = max(0.0, t - PREROLL_S)
+            seek = ["-ss", str(coarse), "-i", str(media), "-ss", str(t - coarse)]
+        else:
+            # Last resort: decode from the start. Only reached when even the
+            # coarse seek lands nowhere.
+            seek = ["-i", str(media), "-ss", str(t)]
         cmd = [
             _tool("ffmpeg"), "-nostdin", "-hide_banner", "-loglevel", "error", "-y",
             *seek, "-frames:v", "1", "-q:v", "2",

--- a/jaano/media.py
+++ b/jaano/media.py
@@ -248,6 +248,26 @@ def has_video(media: Path) -> bool:
     return bool(info.get("streams"))
 
 
+def _duration(media: Path) -> float | None:
+    """Seconds of video, or None if ffprobe will not say.
+
+    Used only to decide whether a failed frame extraction deserves the
+    "past the end" diagnosis. None means "do not claim to know".
+    """
+    proc = subprocess.run(
+        [_tool("ffprobe"), "-v", "error", "-select_streams", "v:0",
+         "-show_entries", "stream=duration", "-show_entries", "format=duration",
+         "-of", "default=nw=1:nk=1", str(media)],
+        capture_output=True, text=True, check=False,
+    )
+    for line in proc.stdout.split():
+        try:
+            return float(line)
+        except ValueError:
+            continue
+    return None
+
+
 def extract_frame(media: Path, t: float, dest: Path, *, width: int | None = None) -> Path:
     """Write the frame at `t` seconds of `media` to `dest`.
 
@@ -281,36 +301,57 @@ def extract_frame(media: Path, t: float, dest: Path, *, width: int | None = None
     if not has_video(media):
         raise NoVideoStream(f"{media} has no video stream, so there is no frame at {t}s.")
 
-    cmd = [
-        _tool("ffmpeg"),
-        "-nostdin",
-        "-hide_banner",
-        "-loglevel", "error",
-        "-y",
-        # -ss BEFORE -i is the fast form: ffmpeg seeks the container instead of
-        # decoding from zero, which on a 33-minute file is the difference
-        # between milliseconds and half a minute. It has been frame-accurate
-        # since 2.1 -- the old "input seeking is approximate" advice predates
-        # that and would cost a full decode to avoid a problem that is gone.
-        "-ss", str(t),
-        "-i", str(media),
-        "-frames:v", "1",
-        "-q:v", "2",
-    ]
-    if width is not None:
-        cmd += ["-vf", f"scale={width}:-2"]  # -2, not -1: keeps the height even
-    cmd.append(str(dest))
+    if not dest.parent.is_dir():
+        # Checked before ffmpeg runs. Otherwise ENOENT on the parent surfaces as
+        # "Nothing was written into output file" and gets blamed on the
+        # timestamp -- which is the mistake a caller writing frames into a
+        # scratch directory it forgot to create will actually make.
+        raise MediaError(
+            f"cannot write {dest}: the directory {dest.parent} does not exist."
+        )
 
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    # Both conditions, not just the exit code. A seek past the end of the file
-    # fails deep in the encoder -- observed exit 234 with "Nothing was written
-    # into output file" buried under nine lines of thread teardown -- and the
-    # useful diagnosis is the missing file, not that log.
+    def _run(fast: bool) -> subprocess.CompletedProcess[str]:
+        # -ss BEFORE -i is the fast form: ffmpeg seeks the container rather than
+        # decoding from zero, which on a 33-minute file is milliseconds against
+        # half a minute. It is frame-accurate for containers carrying an index.
+        # -ss AFTER -i decodes forward from the start: slow, but it works on
+        # containers where the fast form finds nothing.
+        seek = ["-ss", str(t), "-i", str(media)] if fast else ["-i", str(media), "-ss", str(t)]
+        cmd = [
+            _tool("ffmpeg"), "-nostdin", "-hide_banner", "-loglevel", "error", "-y",
+            *seek, "-frames:v", "1", "-q:v", "2",
+        ]
+        if width is not None:
+            cmd += ["-vf", f"scale={width}:-2"]  # -2, not -1: keeps the height even
+        cmd.append(str(dest))
+        return subprocess.run(cmd, capture_output=True, text=True, check=False)
+
+    # Both conditions, not just the exit code. A seek that lands nowhere fails
+    # deep in the encoder -- observed exit 234 with "Nothing was written into
+    # output file" under nine lines of thread teardown -- and the useful
+    # diagnosis is the missing file, not that log.
+    proc = _run(fast=True)
     if proc.returncode != 0 or not dest.exists():
+        # Fall back to decoding forward. MPEG-TS has no global index, so the
+        # fast seek returns nothing at a timestamp the file plainly contains --
+        # measured: extract_tile_grid reads all 6 seconds of a .ts that
+        # extract_frame could not open at t=3. An index whose entries cannot be
+        # opened is worse than no index, so pay the decode rather than fail.
+        proc = _run(fast=False)
+
+    if proc.returncode != 0 or not dest.exists():
+        duration = _duration(media)
+        # Only blame the timestamp when the timestamp is actually to blame.
+        # This hint used to be appended unconditionally, which is how the
+        # MPEG-TS seek failure above hid for as long as it did.
+        hint = (
+            f"{t}s is past the end of this {duration:.1f}s recording."
+            if duration and t > duration
+            else "ffmpeg read the file but produced no frame; its log is above."
+        )
         raise MediaError(
             f"ffmpeg could not extract a frame at {t}s from {media} "
-            f"(exit {proc.returncode}):\n{proc.stderr.strip()}\n"
-            f"The usual cause is a timestamp past the end of the recording."
+            f"(exit {proc.returncode}):\n{proc.stderr.strip()}\n{hint}"
         )
     return dest
 

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -278,3 +278,51 @@ def test_past_the_end_still_says_past_the_end(video: Path, tmp_path: Path) -> No
 
     with pytest.raises(MediaError, match="past the end of this"):
         main(["dikhao", str(video), "9999", "-o", str(tmp_path / "f.jpg")])
+
+
+def _brightness_ramp(tmp_path: Path, container: str, gop: int = 30) -> Path:
+    """A clip whose brightness rises with time, so a frame identifies its second."""
+    master = tmp_path / "ramp.mp4"
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-f", "lavfi",
+         "-i", "color=c=black:s=160x120:d=10:r=25",
+         "-vf", "geq=lum='clip(T*25,0,255)':cb=128:cr=128",
+         "-g", str(gop), "-pix_fmt", "yuv420p", str(master)],
+        check=True,
+    )
+    if container == "mp4":
+        return master
+    dest = tmp_path / f"ramp.{container}"
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", str(master), "-c", "copy",
+         "-f", "mpegts" if container == "ts" else container, str(dest)],
+        check=True,
+    )
+    return dest
+
+
+def test_the_frame_comes_from_the_second_that_was_asked_for(tmp_path: Path) -> None:
+    """Not merely *a* frame -- the RIGHT frame, on a container with no index.
+
+    The first fix here only fell back when the fast seek produced nothing. On an
+    MPEG-TS carrying periodic keyframes the fast seek SUCCEEDS and snaps forward
+    to the next keyframe, so `dikhao` returned the picture from t=9 when asked
+    for t=8, with exit 0 and no warning. For a tool whose promise is "the frame
+    at this timestamp", silently late is as bad as silently wrong.
+    """
+    ts = _brightness_ramp(tmp_path, "ts")
+    mp4 = tmp_path / "ramp.mp4"
+
+    for second in (3, 8):
+        want = tmp_path / f"want{second}.jpg"
+        got = tmp_path / f"got{second}.jpg"
+        # ground truth: a full accurate decode of the indexed master
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-i", str(mp4), "-ss", str(second),
+             "-frames:v", "1", str(want)],
+            check=True,
+        )
+        assert main(["dikhao", str(ts), str(float(second)), "-o", str(got), "--width", "0"]) == 0
+        assert abs(_mean_grey(got) - _mean_grey(want)) <= 2, (
+            f"asked for t={second}s and got a frame from elsewhere in the ramp"
+        )

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -224,3 +224,57 @@ def test_the_installed_console_script_works() -> None:
     assert proc.returncode == 0, proc.stderr
     for verb in ("transcribe", "mark", "frame"):
         assert verb in proc.stdout, proc.stdout
+
+
+# --------------------------------------------------------------------------
+# Containers the mark pass can read, the frame pass must be able to open
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def transport_stream(video: Path, tmp_path: Path) -> Path:
+    """The same content remuxed to MPEG-TS, which carries no global index."""
+    dest = tmp_path / "v.ts"
+    subprocess.run(
+        ["ffmpeg", "-y", "-loglevel", "error", "-i", str(video), "-c", "copy",
+         "-f", "mpegts", str(dest)],
+        check=True,
+    )
+    return dest
+
+
+def test_a_frame_can_be_pulled_from_a_container_with_no_index(
+    transport_stream: Path, tmp_path: Path
+) -> None:
+    """An index whose entries cannot be opened is worse than no index.
+
+    MPEG-TS has no global header, so `-ss` BEFORE `-i` seeks to nothing and
+    ffmpeg writes no frame -- at a timestamp the file plainly contains. Measured
+    before the fix: extract_tile_grid read all 6 seconds of a .ts that
+    extract_frame could not open at t=3, and the error blamed the timestamp.
+    """
+    dest = tmp_path / "f.jpg"
+    assert main(["dikhao", str(transport_stream), "6.0", "-o", str(dest)]) == 0
+    assert dest.exists()
+    assert _mean_grey(dest) > 192, "must land in the second, near-white half"
+
+
+def test_a_missing_output_directory_says_so(video: Path, tmp_path: Path) -> None:
+    """Not 'a timestamp past the end' -- that hint used to be unconditional.
+
+    Writing frames into a scratch directory it forgot to create is the mistake
+    a calling agent actually makes, and it was being pointed at the wrong
+    variable.
+    """
+    from jaano.media import MediaError
+
+    with pytest.raises(MediaError, match="does not exist"):
+        main(["dikhao", str(video), "1.0", "-o", str(tmp_path / "nope" / "f.jpg")])
+
+
+def test_past_the_end_still_says_past_the_end(video: Path, tmp_path: Path) -> None:
+    """The hint is now conditional, so prove it still fires when it should."""
+    from jaano.media import MediaError
+
+    with pytest.raises(MediaError, match="past the end of this"):
+        main(["dikhao", str(video), "9999", "-o", str(tmp_path / "f.jpg")])

--- a/tests/test_dekho.py
+++ b/tests/test_dekho.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+import jaano.dekho as dekho_mod
 from jaano import media
 from jaano.dekho import (
     DEFAULT_DELTA,
@@ -588,3 +589,42 @@ def test_the_cli_honours_an_explicit_output(
     assert main([str(cut_video), "-t", str(transcript), "-o", str(out)]) == 0
     assert "marks" in json.loads(out.read_text())
     assert "marks" not in json.loads(transcript.read_text())
+
+
+# --------------------------------------------------------------------------
+# The transcript is the user's file, and the mark pass writes over it
+# --------------------------------------------------------------------------
+
+
+@needs_ffmpeg
+def test_a_json_array_transcript_is_refused_not_silently_destroyed(
+    cut_video: Path, tmp_path: Path
+) -> None:
+    """The worst thing this tool could do, and it took one isinstance to stop.
+
+    `dict()` accepts any iterable of pairs. A transcript that is a JSON ARRAY of
+    objects satisfies that by accident, because each object iterates as its
+    keys -- so `[{"start": 0, "text": "hi"}]` becomes `{"start": "text"}`, and
+    mark_video wrote that back over the input. Observed before the fix: a real
+    transcript replaced by a two-key stub.
+    """
+    bad = tmp_path / "array.json"
+    original = '[{"start": 0, "text": "hello"}]'
+    bad.write_text(original)
+
+    with pytest.raises(dekho_mod.MarkError, match="expected a JSON object"):
+        mark_video(cut_video, bad, bad)
+
+    assert bad.read_text() == original, "the input must survive a rejected run"
+
+
+@needs_ffmpeg
+@pytest.mark.parametrize("payload", ['"a string"', "42", "null", "[]"])
+def test_every_non_object_transcript_is_refused(
+    cut_video: Path, tmp_path: Path, payload: str
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(payload)
+    with pytest.raises(dekho_mod.MarkError):
+        mark_video(cut_video, bad, bad)
+    assert bad.read_text() == payload


### PR DESCRIPTION
Three defects found by an adversarial review, each **reproduced by hand before being fixed**, each pinned by a test **proven to fail on the old code**.

## 1. A JSON-array transcript was silently destroyed

```
$ printf '[{"start": 0, "text": "hello"}]' > t.json
$ jaano dekho video.mp4 -t t.json
0 marks over 2 sampled frames in 0s          # exit 0, no warning
$ cat t.json
{"start": "text", "marks": [], "marks_meta": {…}}     # the transcript is gone
```

`dict()` accepts any iterable of pairs, and a list of objects satisfies that by accident because each object iterates as its keys. `mark_video` then wrote the result back over the user's file.

Validated at the trust boundary — where `json.loads` returns `Any` — not downstream where the annotation already claims `dict`. A new `MarkError` names what was found and what was expected.

## 2. `dikhao` could not open frames from a container `dekho` reads fine

```
$ jaano dekho  file.ts        →  6 frames scanned, fine
$ jaano dikhao file.ts 3.0    →  nothing, "timestamp past the end"   (of a 6-second file)
```

MPEG-TS has no global index, so `-ss` before `-i` seeks to nothing. **An index whose entries cannot be opened is worse than no index**, so the fast seek now falls back to decoding forward.

## 3. Every frame failure blamed the timestamp

The "past the end of the recording" hint was appended unconditionally. That is *how bug 2 stayed hidden*, and it is what a caller writing into a scratch directory it forgot to create was told.

Now: a missing output directory is checked before ffmpeg runs and named; the past-the-end hint fires only when ffprobe says the timestamp really is past the end; anything else says plainly that ffmpeg read the file and produced no frame.

```
$ jaano dikhao v.ts 3.0 -o /tmp/nope/f.jpg
cannot write /tmp/nope/f.jpg: the directory /tmp/nope does not exist.

$ jaano dikhao v.ts 999 -o /tmp/f.jpg
999.0s is past the end of this 6.0s recording.
```

## The review's only CRITICAL was wrong, and is not fixed

It reported a permanent deadlock in `extract_tile_grid`, marked *PROVEN* with `ps` and `sample` traces of three live hangs. The hangs were real; the attribution was not.

The premise is that `read()` can return short before EOF. `proc.stdout` is an `io.BufferedReader`, whose `read(n)` blocks until n bytes or EOF — measured at 100 frames through a real ffmpeg pipe, **zero short reads**. The hangs were a sibling review agent's mutant (`<` → `<=`), which breaks after frame 1 and leaves the pipe undrained.

What survives is a hardening gap, **filed not fixed**: `proc.wait()` has no timeout, so any early break turns a test failure into an unkillable hang. A one-character regression hung the suite for 8 minutes and `pytest --timeout=120` did not rescue it.

## Verification

Each new test was run against the reverted fix and observed to fail:

| Reverted | Test that caught it |
|---|---|
| the `isinstance` guard | `test_every_non_object_transcript_is_refused` |
| the decode-forward fallback | `test_a_frame_can_be_pulled_from_a_container_with_no_index` |
| the output-directory check | `test_a_missing_output_directory_says_so` |

`just check` green: **207 passed**, pyright strict clean, ruff clean. CI floor 199 → 207.

Also filed, not in this PR: the README install path produces no working command, `uv build` fails on an ungitignored absolute symlink, no LICENSE, and `numba` is declared but never imported.
