### PR TITLE
fix(verify): measure coverage of jaano, and fail when it measures nothing

### DIFF
--- a/justfile
+++ b/justfile
@@ -35,9 +35,16 @@ check: typecheck
 # that makes deselecting the slow tests honest rather than a quiet loss.
 # `-m "slow or not slow"` rather than `-m ""`: it unambiguously overrides the
 # deselection in addopts, and empty-marker behaviour is not worth relying on.
+#
+# --cov-fail-under is not a quality bar, it is a LIVENESS check. This line said
+# `--cov=deixis` for as long as the package has been called jaano: coverage
+# collected nothing, printed "Module deixis was never imported" and "No data
+# was collected" into the middle of a 22-minute run, and exited 0. Every
+# coverage number quoted after the rename measured a package that did not
+# exist. A floor turns that silence into a failure -- no data reads as 0%.
 verify: typecheck
     uv run ruff check .
-    uv run pytest -m "slow or not slow" --cov=deixis --cov-report=term-missing:skip-covered
+    uv run pytest -m "slow or not slow" --cov=jaano --cov-report=term-missing:skip-covered --cov-fail-under=90
 
 # Mutation testing over the three pure modules. Coverage proves a line ran;
 # this proves the suite would notice if it stopped. Survivors are the


### PR DESCRIPTION
Closes jaano-bro.

`just verify` has run `pytest --cov=deixis` for as long as the package has been called `jaano`. coverage collected nothing and said so —

```
CoverageWarning: Module deixis was never imported. (module-not-imported)
CoverageWarning: No data was collected. (no-data-collected)
WARNING: Failed to generate report: No data to report.
235 passed in 1320.54s (0:22:00)
```

— buried in the middle of a 22-minute run, and then **exited 0**. Every coverage number quoted since the rename described a package that does not exist.

## The change

```diff
-uv run pytest -m "slow or not slow" --cov=deixis --cov-report=term-missing:skip-covered
+uv run pytest -m "slow or not slow" --cov=jaano --cov-report=term-missing:skip-covered --cov-fail-under=90
```

`--cov=jaano` is the fix. `--cov-fail-under` is the part that matters more: **it is not a quality bar, it is a liveness check.** No data reads as 0%, so a floor turns that silence into a failure the next time a rename or a typo detaches the measurement from the code.

## The observed number

90 sits well under reality. The **fast lane alone**, every slow test deselected:

| | Stmts | Miss | Cover |
|---|---|---|---|
| TOTAL | 707 | 21 | **97%** |

(`asr.py` and `whisper.py` are among the six files at 100%.) The full run can only be higher.

A check that passes because it is not looking is what `docs/tooling-gaps.md` exists to prevent, and this was one.
