### PR TITLE
docs(vlm): Qwen3-VL-4B reads the screen; speed is the new blocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ only where the transcript says something visual happened.
 | Does frame retrieval help an agent? | **5/16 → 16/16** on blind-graded questions | [do-marks-help.md](docs/do-marks-help.md) |
 | Do the change marks beat chance? | **701/834** third-party recordings, p = 3.5e-94 | [generalisation.md](docs/generalisation.md) |
 | On hour-long recordings? | **81%** of slide changes caught within 2s, vs 42% random | [generalisation.md](docs/generalisation.md) |
-| Can a small local VLM read a screen? | **No** — 47% recall, 18 fabrications | [vlm-legibility.md](docs/vlm-legibility.md) |
+| Can a small local VLM read a screen? | **86%** recall on the second model tried, at 156 s/frame | [vlm-legibility.md](docs/vlm-legibility.md) |
 | Where does it fail? | A camera pointed at a screen. Documented, not hidden | [generalisation.md](docs/generalisation.md) |
 
 Every number came from a command. Three change detectors were built, measured
@@ -327,7 +327,7 @@ can fail. That cost is the point — see [docs/tooling-gaps.md](docs/tooling-gap
 | [docs/visual-marks.md](docs/visual-marks.md) | the three change detectors that were built and measured before this one, and why each failed |
 | [docs/generalisation.md](docs/generalisation.md) | two external benchmarks with human ground truth — 834 GUI recordings (p = 3.5e-94) and five hour-long lectures (81% of slide changes caught within 2s) |
 | [docs/do-marks-help.md](docs/do-marks-help.md) | do the marks actually help an agent? Three arms, blind-graded: 5/16 → 7/16 → 16/16 |
-| [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Measured: not this one |
+| [docs/vlm-legibility.md](docs/vlm-legibility.md) | whether a small local VLM can read a screen frame. Two models, five prompts and budgets, one ground truth: 47% → 86%, and the blocker moves from legibility to speed |
 
 ---
 
@@ -414,15 +414,16 @@ inventing invalidation and leaving 135 MB files next to the user's recordings.
 Anyone who wants the wav can extract it by hand and pass it — the conversion
 step is skipped when the input is already mono `pcm_s16le` at the model's rate.
 
-**Vision, not OCR — but which vision model is now an open question.**
-The plan named Qwen2.5-VL-7B-Instruct on `mlx-vlm`, on the strength of published
-DocVQA and ChartQA scores. That model has still never been run here. What *has*
-been run is `gemma-4-e2b-it-4bit`, on five frames from a real recording with
-ground truth written down first: 47% recall and 18 fabricated strings, at
-18-22 s per image. Benchmark leadership on document QA did not survive contact
-with a screenshot of an inbox — see
-[docs/vlm-legibility.md](docs/vlm-legibility.md) — so the model choice is
-deliberately reopened rather than carried forward.
+**Vision, not OCR — and the model is now chosen on measurement, not on
+benchmarks.** The plan named Qwen2.5-VL-7B-Instruct on `mlx-vlm`, on the strength
+of published DocVQA and ChartQA scores; it has still never been run here, and the
+reason is now that it would be slower on the axis that blocks. Two models were
+measured on five frames from a real recording against ground truth written down
+first: `gemma-4-e2b-it-4bit` recalls 47% while fabricating 18 strings, and
+`Qwen3-VL-4B-Instruct-4bit` recalls 86% on the identical prompt — but takes 156 s
+per frame against gemma's 24. See
+[docs/vlm-legibility.md](docs/vlm-legibility.md): the legibility question is
+answered, and throughput replaced it as the open one.
 
 **Speaker labels: senko, optional, and wrong in ways worth naming.**
 Diarization is an extra — the `[diarize]` install above — not a dependency. It pulls
@@ -518,12 +519,17 @@ Frame *selection* is answered. Frame *description* is not.
   across five real frames (47%) while fabricating 18 — and the fabrications are
   fluent, plausible UI text (`Your GPS aren't the problem`, `OpenAI Browser`),
   which is the kind that poisons an index silently. Resolution is not the fix:
-  700 → 1600 px moved recall by one string.
-- It is also 18–22 s per image, not the ~5 s assumed from an earlier benchmark
-  whose outputs were 23–26 tokens long.
-- Untested and worth trying before concluding anything general: a larger local
-  model (`Qwen3-VL-4B`), a terse prompt with a larger token budget, and a cloud
-  VLM — none of which have been run.
+  700 → 1600 px moved recall by one string. Neither is the token budget: tripling
+  it to 1200 returned the identical 33/70, string for string.
+- `Qwen3-VL-4B-Instruct-4bit` on the same frames, same ground truth and same
+  prompt recovers **60 of 70 (86%)**, including the matrix column headers and the
+  message body that gemma missed entirely. Legibility is no longer what blocks.
+- What blocks now is 156 s per frame — about 6.5 hours of description for a
+  33-minute recording at 150 marks, on a fanless machine. Cutting the frame
+  count, cropping to the changed region, or accepting an overnight batch are the
+  levers, and none is measured yet.
+- A terse "text only, no headings" prompt makes both models worse, not better:
+  each degenerates into a repeat loop on the densest frame.
 - **ColPali / ColQwen2** (late-interaction retrieval over page images, no OCR)
   remains the interesting alternative, but no MLX port exists and nobody reports
   running `colpali-engine` on Apple Silicon MPS. Experiment, not infrastructure.

--- a/docs/vlm-legibility.md
+++ b/docs/vlm-legibility.md
@@ -1,10 +1,16 @@
-# Can a small local VLM read a screen recording? Measured: no
+# Can a small local VLM read a screen recording? One of them can, slowly
 
 Describing the marked frames is the obvious next step after
 [visual-marks.md](visual-marks.md), and the plan was to do it locally: free,
 private, no API key, no uploads. Before building it, one question had to be
 answered, because everything downstream depends on it — **can a 2–4B model
 running on this machine actually read dense on-screen text?**
+
+The first model tried could not, and the write-up below records that. A second
+round on 2026-08-12 tested the three things the first round named as untested;
+one of them works. **[Jump to the second round](#second-round-2026-08-12)** for
+the answer and the numbers; the first-round detail stays because it is what the
+second round is measured against.
 
 Measured 2026-08-08 on the M2 MacBook Air (16 GB, fanless). Raw output,
 driver and hand-written ground truth are under `scratch/vlm/`.
@@ -105,3 +111,133 @@ At 150 marks that is **45–55 minutes per 33 minutes of video**, not the
 What it *does* rule out is shipping a describer on this model as it was
 configured, and it rules out temperature as the remedy — the run was already
 greedy, so the garbling is the model's best guess and not noise.
+
+## Second round, 2026-08-12
+
+All three of the above were tested, on the **same five frames against the same
+ground truth file, unedited**. Same machine, same runtime, same greedy decoding.
+
+Recall is now scored by `scratch/vlm/score.py` rather than by hand. It implements
+the rule the first round wrote down and nothing more — case-insensitive substring
+match, whitespace collapsed, markdown and table markers stripped. Deliberately no
+fuzzy matching: a fuzzy matcher would score `Your GPS aren't the problem` as a hit
+for `Your GPUs …`, and that substitution is the failure this measurement exists to
+catch. Run against the first round's raw output it reproduces its numbers exactly
+— 33/70 overall, 4 / 8 / 10 / 2 / 9 per frame — so the scoring rule did not move
+and the rows below are comparable. Hallucinations are still counted by hand,
+because counting them needs the image, not a string list.
+
+`run_config.py` takes model, prompt and token budget as arguments; `run.py` is
+left pinned to the first round's configuration.
+
+| # | Model | Prompt | `max_tokens` | Recalled / 70 | Hallucinated | Mean s/frame |
+|---|---|---|---|---|---|---|
+| 1 | `gemma-4-e2b-it-4bit` | descriptive | 400 | **33 (47%)** | 18 | 24 |
+| 2 | `gemma-4-e2b-it-4bit` | descriptive | 1200 | **33 (47%)** | 18 | 45 |
+| 3 | `gemma-4-e2b-it-4bit` | terse | 1200 | **17 (24%)** | 14 | 20 |
+| 4 | `Qwen3-VL-4B-Instruct-4bit` | descriptive | 1200 | **60 (86%)** | 18 | 156 |
+| 5 | `Qwen3-VL-4B-Instruct-4bit` | terse | 1200 | **56 (80%)** | 13 | 124 |
+
+Row 1 is the first round, rescored. "Descriptive" is its prompt verbatim; "terse"
+is *"Output only the text you can see in this screenshot, exactly as written. No
+headings, no description, no commentary, no explanation. Text only."*
+
+### The token budget was not the constraint
+
+Row 2 tripled the budget and changed nothing: same 33/70, the same per-frame
+4 / 8 / 10 / 2 / 9, the same fabrications, the same two structural failures — the
+Google Form matrix still came back without a single column header, the radio
+question `Verification, judgment & data safety` and its selected `Basic` still
+absent. The extra 800 tokens bought more markdown scaffolding and 21 more seconds
+per frame. The first round's guess that the model "runs out mid-frame" was wrong:
+it was not running out, it had already said what it could read.
+
+### The terse prompt is actively harmful, on both models
+
+Rows 3 and 5 are the surprise. Told to emit text and nothing else, **both** models
+degenerate into a repeat loop on the dense inbox frame — gemma emitted `Pascal
+Nass / Votre Kit Transformation est prêt / PN / Journal fourni / Courriers du
+dossier Autres (1)` forty times until the budget ran out (83 s); Qwen emitted
+`pascal nass / @ : @ muhammadmoiz.work / Cci : pascal nass` about thirty times
+(256 s, its slowest frame of any run).
+
+On the other four frames gemma did the opposite and stopped almost immediately —
+3.0 s and 133 characters on `UNDET_01195`, of which the entire content was the
+macOS notification in the corner, scoring **0/15**. It also invented framing it
+had not invented under the descriptive prompt: on the Google Form matrix it
+produced `Welcome to the team.` / `Please select a topic from the list below.`,
+neither of which appears anywhere on screen.
+
+The descriptive prompt's headings are not waste. They are what gives the model a
+structure to walk and a place to stop.
+
+### The model was the constraint
+
+Row 4 is the result. `Qwen3-VL-4B-Instruct-4bit` (2.5 GB download, 4-bit) on the
+unchanged first-round prompt recovers **60 of 70** strings against gemma's 33, and
+both of the structural failures reverse:
+
+- All five matrix column headers — `<2hr`, `>2 & <4hr`, `>4 & <6hr`, `>6 & <8hr`,
+  `>8hr` — plus all six row labels. That frame goes from 2/14 to **14/14**.
+- The radio question and its selected value, `Verification, judgment & data
+  safety` / `Basic`, both present. That frame goes from 10/15 to **14/15**.
+- The Outlook reading pane — `Hello Moiz`, `Here my feedback`, `1 Entry point`,
+  `Which role do you hold?` — the four strings gemma recalled **0/4 at every
+  resolution**, all four read correctly. That is the actual message content, the
+  part a describer exists to capture.
+
+The hallucination count is unchanged at 18, and that number deserves care rather
+than celebration. What changed is *where* they are and *what* they are. Eleven of
+the 18 are on the single dense inbox frame, and they are proper nouns, URLs and
+brand strings — `OpenCBI Browser` for `OpenCLI Browser`, `Merlyn from Packet` for
+`Merlyn from Packt`, `Vushank Pandya` for `Vrushank Pandya`, and a merge of two
+adjacent rows into `Hi Daniel Priestley`. Participant names garble on three
+frames: `Moiz` came back as `Mat`, `Moaz` and `Mozi`. That is still the dangerous
+class — fluent and plausible — but it is now concentrated in the metadata rather
+than spread through the body text, which is a different failure to design around.
+
+One defect is worth naming on its own: on the inbox frame the model finished its
+transcription and then emitted the integers 1 through 100 as a bulleted list under
+`**Other UI Elements:**`. Pure invention, and it is roughly a third of that
+frame's 222 seconds.
+
+### The constraint is now speed
+
+156 s per frame, mean over the five, against gemma's 24. Per frame: 222, 97, 140,
+193, 125 — the dense frames cost the most, which is also where the marks land.
+
+At the 150 marks a 33-minute recording produces that is **about 6.5 hours of
+description for 33 minutes of video**, roughly 12x realtime, on a fanless machine
+that will be thermally throttled long before it finishes. The first round already
+found gemma at 45–55 minutes per 33 minutes against a plan that assumed ~1:1;
+this is eight times worse than that.
+
+Row 5 was run to see whether the terse prompt could buy the time back by cutting
+the description prose. It does not: 124 s mean, still 20x gemma, and it costs four
+recalled strings. Not a trade worth making.
+
+## Where this leaves the describer
+
+**The capability question is answered, and the answer flipped.** A 4B model on
+this machine can read a dense screen frame — 86% of hand-written ground truth,
+including the matrix axes and message body that the first round called
+"unusable". `Qwen3-VL-4B-Instruct-4bit` with the descriptive prompt is the
+configuration to build on. The first round's verdict was correct about the model
+it tested and wrong as a general claim about small local VLMs.
+
+**The blocking question is now throughput, not legibility.** 12x realtime is not
+a describer anybody runs on an hour of video. That is the next thing to decide,
+and it is a different problem with different levers — fewer frames described,
+cropping to the changed region rather than passing the full frame, batching, or
+accepting an overnight batch job. None of those have been measured.
+
+Two things were deliberately **not** run, with reasons:
+
+- **`Qwen2.5-VL-7B`**, named in the plan since the start. The binding constraint
+  is now seconds per frame, and a 7B model on 16 GB is strictly worse on exactly
+  that axis. Testing it would answer a question that is no longer the one in the
+  way.
+- **A cloud VLM.** It was not called and not priced, so this document contains no
+  cost figure for it. It stops being the obvious escape hatch the moment a local
+  model clears the legibility bar, because the reason for local — no uploads of
+  someone's inbox and video call — was never about capability.

--- a/scratch/vlm/run_config.py
+++ b/scratch/vlm/run_config.py
@@ -1,0 +1,71 @@
+"""Run one (model, prompt, max_tokens) configuration over the frame set.
+
+run.py pinned the exact configuration measured on 2026-08-08 and is left alone so
+that measurement stays reproducible. This script takes the same shape but lets
+the three variables the 2026-08-08 write-up named as untested — model, prompt
+wording, token budget — move independently, so a later run differs from the
+baseline in a known way rather than an unknown one.
+
+Decoding is left at mlx-vlm's default, which is greedy (`DEFAULT_TEMPERATURE`
+is 0.0), matching the baseline: every reading is the model's argmax, so any
+difference against the baseline is the configuration and not sampling noise.
+
+Usage:
+    python run_config.py --model M --prompt-file P --max-tokens N --out O IMG...
+"""
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+from mlx_vlm import generate, load
+from mlx_vlm.prompt_utils import apply_chat_template
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--prompt-file", required=True)
+    parser.add_argument("--max-tokens", type=int, required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("images", nargs="+")
+    args = parser.parse_args()
+
+    prompt = Path(args.prompt_file).read_text().strip()
+
+    t0 = time.perf_counter()
+    model, processor = load(args.model)
+    config = model.config
+    load_s = time.perf_counter() - t0
+    print(f"model load: {load_s:.1f}s", flush=True)
+
+    results = []
+    for path in args.images:
+        formatted = apply_chat_template(processor, config, prompt, num_images=1)
+        t = time.perf_counter()
+        out = generate(
+            model, processor, formatted, [path], max_tokens=args.max_tokens, verbose=False
+        )
+        elapsed = time.perf_counter() - t
+        text = out.text if hasattr(out, "text") else str(out)
+        print(f"{path}: {elapsed:.1f}s, {len(text)} chars", flush=True)
+        results.append({"image": path, "seconds": round(elapsed, 1), "output": text})
+
+    Path(args.out).write_text(
+        json.dumps(
+            {
+                "model": args.model,
+                "prompt": prompt,
+                "max_tokens": args.max_tokens,
+                "load_seconds": round(load_s, 1),
+                "results": results,
+            },
+            indent=2,
+            ensure_ascii=False,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scratch/vlm/score.py
+++ b/scratch/vlm/score.py
@@ -1,0 +1,80 @@
+"""Score a raw_output.json against the hand-written ground truth.
+
+The 2026-08-08 gemma run scored recall by hand-applying the rule written down in
+scratch/vlm/RESULTS.md: case-insensitive substring match, whitespace collapsed,
+markdown list markers stripped. Re-running that rule as code is the only way a
+later run is comparable to it, so this script implements exactly that rule and
+nothing more — it deliberately does no fuzzy matching, because a fuzzy match
+would score `Your GPS aren't the problem` as a hit for `Your GPUs ...`, and that
+substitution is the failure the measurement exists to catch.
+
+Hallucinations are not scored here. They cannot be: counting them requires
+comparing the output against the image, not against a string list.
+
+Usage:
+    python score.py <ground_truth.md> <raw_output.json>
+"""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+HEADING = re.compile(r"^## (\S+\.jpg)")
+# Some ground-truth items carry a trailing parenthetical note outside the
+# backticks (`... ` (browser tab title)), so match the first backticked span
+# rather than requiring it to run to end of line.
+ITEM = re.compile(r"^\d+\.\s+`([^`]+)`")
+
+
+def normalize(text: str) -> str:
+    """Lowercase, drop markdown list/table markers, collapse whitespace."""
+    text = re.sub(r"[*|#`]", " ", text)
+    return re.sub(r"\s+", " ", text).strip().lower()
+
+
+def load_ground_truth(path: Path) -> dict[str, list[str]]:
+    truth: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in path.read_text().splitlines():
+        heading = HEADING.match(line)
+        if heading:
+            current = heading.group(1)
+            truth[current] = []
+            continue
+        item = ITEM.match(line)
+        if item and current is not None:
+            truth[current].append(item.group(1))
+    return truth
+
+
+def main() -> None:
+    truth = load_ground_truth(Path(sys.argv[1]))
+    raw = json.loads(Path(sys.argv[2]).read_text())
+
+    total_gt = 0
+    total_hit = 0
+    rows: list[tuple[str, int, int, float]] = []
+    for entry in raw["results"]:
+        name = Path(entry["image"]).name
+        if name not in truth:
+            continue
+        output = normalize(entry["output"])
+        strings = truth[name]
+        hits = [s for s in strings if normalize(s) in output]
+        misses = [s for s in strings if normalize(s) not in output]
+        rows.append((name, len(hits), len(strings), float(entry["seconds"])))
+        total_gt += len(strings)
+        total_hit += len(hits)
+        print(f"\n{name}: {len(hits)}/{len(strings)}  ({entry['seconds']}s)")
+        for s in misses:
+            print(f"    MISS  {s}")
+
+    print(f"\nmodel: {raw.get('model')}  max_tokens: {raw.get('max_tokens')}")
+    print(f"TOTAL recall: {total_hit}/{total_gt} " f"({100 * total_hit / total_gt:.0f}%)")
+    for name, hit, n, secs in rows:
+        print(f"  {name}: {hit}/{n} {secs}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Second round on the five-frame legibility set. Same machine, same runtime, same greedy decoding, and the **same hand-written ground truth file unedited**, so every row below is comparable to the 2026-08-08 measurement.

Recall is now scored by `scratch/vlm/score.py`, which implements the rule the first round wrote down (case-insensitive substring, whitespace collapsed, markdown markers stripped) and nothing more — no fuzzy matching, because a fuzzy matcher would score `Your GPS aren't the problem` as a hit for `Your GPUs …`. Run against the first round's raw output it reproduces its numbers exactly: 33/70 overall, 4 / 8 / 10 / 2 / 9 per frame. Hallucinations are still hand-counted against the images.

| # | Model | Prompt | `max_tokens` | Recalled / 70 | Hallucinated | Mean s/frame |
|---|---|---|---|---|---|---|
| 1 | `gemma-4-e2b-it-4bit` | descriptive | 400 | **33 (47%)** | 18 | 24 |
| 2 | `gemma-4-e2b-it-4bit` | descriptive | 1200 | **33 (47%)** | 18 | 45 |
| 3 | `gemma-4-e2b-it-4bit` | terse | 1200 | **17 (24%)** | 14 | 20 |
| 4 | `Qwen3-VL-4B-Instruct-4bit` | descriptive | 1200 | **60 (86%)** | 18 | 156 |
| 5 | `Qwen3-VL-4B-Instruct-4bit` | terse | 1200 | **56 (80%)** | 13 | 124 |

Row 1 is the first round, rescored by the script.

## What each option turned out to be

**The token budget was not the confounder.** Row 2 tripled it and returned the identical 33/70 — same per-frame split, same fabrications, same two structural failures (no matrix column headers, the `Verification, judgment & data safety` / `Basic` row still absent). The model was not running out of budget; it had already said what it could read.

**The terse prompt is actively harmful, on both models.** Told to emit text and nothing else, each degenerates into a repeat loop on the dense inbox frame — gemma repeats a five-line block forty times, Qwen repeats a three-line block about thirty times (256 s, its slowest frame of any run). On the other four frames gemma stops almost immediately: 3.0 s and 133 characters on `UNDET_01195`, all of it the macOS notification in the corner, scoring 0/15. The descriptive prompt's headings are what give the model a structure to walk and a place to stop.

**The model was the constraint.** `Qwen3-VL-4B-Instruct-4bit` on the unchanged prompt reverses both structural failures: the Google Form matrix goes 2/14 → **14/14** with all five column headers, the radio question and its selected value both appear, and the Outlook reading pane — `Hello Moiz`, `Here my feedback`, `1 Entry point`, `Which role do you hold?`, recalled 0/4 by gemma at every resolution — comes back correct.

The hallucination count is unchanged at 18 and that deserves care rather than celebration. What changed is where they are: eleven of the eighteen sit on the single dense inbox frame, and they are proper nouns, URLs and brand strings (`OpenCBI Browser`, `Merlyn from Packet`, `Vushank Pandya`) rather than body text. Participant names garble on three frames. One frame also ends with the integers 1–100 emitted as a bulleted list under a heading of the model's own invention.

## Recommendation

Build on `Qwen3-VL-4B-Instruct-4bit` with the descriptive prompt. The legibility question the first round opened is answered, and the answer flipped — a 4B model on this machine does read a dense screen frame.

**The blocking question is now throughput.** 156 s/frame is about 6.5 hours of description for a 33-minute recording at 150 marks, roughly 12x realtime on a fanless machine that will throttle long before it finishes. The levers are fewer described frames, cropping to the changed region, batching, or an accepted overnight job — none measured.

Two things deliberately not run, with reasons in the doc: **Qwen2.5-VL-7B**, because the binding constraint is now seconds per frame and a 7B model on 16 GB is strictly worse on that axis; and **a cloud VLM**, which was not called and therefore carries no cost figure here.

## Verification

`just check` green in this worktree: pyright 0 errors on both configs, ruff clean, 219 passed / 16 deselected. `just verify` was not run — it needs gitignored reference audio absent from the worktree.