### PR TITLE
test: run the install the README publishes, and correct why it broke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,35 @@ on:
   workflow_dispatch:
 
 jobs:
+  # THE PATH THE README PUBLISHES. `check` below runs `uv sync` inside the
+  # project, where .python-version pins the interpreter and the extras are
+  # already synced -- which is not how anyone installs jaano. That divergence
+  # is how a 45-minute recording got transcribed with diarization silently
+  # skipped while the suite stayed green: nothing executed the documented
+  # command.
+  #
+  # Deliberately a CI job rather than only a `just verify` gate. verify is a
+  # session-close ritual that can run AFTER a merge; CI runs before one.
+  install-gate:
+    runs-on: macos-14
+
+    steps:
+      # fetch-depth: 0 because the gate installs from a git+file:// clone of
+      # this checkout, and cloning a shallow repo is not reliable.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v9.0.0
+        with:
+          enable-cache: true
+
+      # No extras here on purpose: the gate builds its own isolated tool
+      # environment and must not be handed a working senko by the runner.
+      - run: uv sync --dev
+
+      - name: the documented install produces a working diarizing jaano
+        run: uv run pytest tests/test_install_gate.py -m "slow or not slow"
+
   check:
     # macos-14 is the Apple Silicon runner. parakeet-mlx requires MLX, which is
     # Metal-backed, so a Linux runner cannot even import the package. Confirmed

--- a/README.md
+++ b/README.md
@@ -86,10 +86,12 @@ the interesting part.
 - **macOS on Apple Silicon.** ASR runs through [`parakeet-mlx`][pmlx], and the
   whisper engine through `mlx-whisper`. Both are Metal-backed; there is no CPU
   or CUDA path.
-- **Python 3.12 or 3.13.** Capped deliberately: the diarize extra reaches
+- **Python 3.12 or 3.13.** Capped deliberately. The diarize extra reaches
   coremltools, which publishes no wheel above 3.13 and no `requires-python` of
-  its own, so an uncapped range let `uv tool install` pick a Python where it
-  built from source and then failed to load.
+  its own; on 3.14 it builds from source into a pure-Python wheel with the
+  CoreML extensions missing. That imports cleanly and then cannot diarize, so
+  the failure arrives as a transcript with no speaker labels rather than as an
+  error. `tests/test_install_gate.py` runs the install below and checks it.
 - **ffmpeg** on `PATH`, for anything that is not already a 16 kHz mono WAV.
 - [`uv`][uv] for dependency management.
 

--- a/jaano/diarize.py
+++ b/jaano/diarize.py
@@ -145,10 +145,10 @@ def _import_senko() -> ModuleType:
         ) from exc
     except ImportError as exc:
         # Not a missing module: a module that is present and refuses to load.
-        # A native extension failing to dlopen lands here, and this branch
-        # exists because it used to land in the one above and be reported as
-        # "not installed" -- an hour of reinstalling something already
-        # installed, with the dlopen error thrown away.
+        # A native extension failing to dlopen lands here. It used to land in
+        # the branch above and be answered with "not installed" -- an install
+        # command for something already installed, with the loader error, the
+        # only useful line, thrown away.
         raise DiarizationUnavailable(_will_not_load(exc)) from exc
     return senko
 
@@ -156,12 +156,16 @@ def _import_senko() -> ModuleType:
 def _will_not_load(exc: ImportError) -> str:
     """The message for an extra that is installed and still will not import.
 
-    Leads with the running interpreter because that is the variable. senko's
-    dependency tree reaches native wheels, wheels are published per Python
-    version, and a version with no wheel gets built from source into something
-    that installs cleanly and fails at dlopen. The exception text names the
-    library that failed; it is the only actionable line in the failure and the
-    old handler discarded it.
+    Leads with the running interpreter because that is the variable: senko's
+    dependency tree reaches native wheels, and wheels are published per Python
+    version. The exception text names the library that failed, which is the
+    only actionable line in the failure, and the old handler discarded it.
+
+    NOT the message for the 3.14 coremltools incident, despite that being what
+    prompted this split. That build does not raise at all -- it imports clean
+    and loses CoreML silently, which is why pyproject caps requires-python and
+    tests/test_install_gate.py checks the wheel tag. This branch covers the
+    louder cousin: an extra that is present and refuses to load.
     """
     return (
         f"senko is installed but will not import on Python "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,14 +3,22 @@ name = "jaano"
 version = "0.1.0"
 description = "Make a long screen recording answerable: a timestamped transcript indexes the video, frames are retrieved on demand."
 readme = "README.md"
-# Capped, not open-ended. `.python-version` pins 3.12 for the PROJECT, but
-# `uv tool install` from a git URL has no project context and never reads it --
-# it takes the newest interpreter this range allows, which on a machine with
-# Homebrew python3 was 3.14. coremltools, reached through the diarize extra,
-# publishes no wheel above 3.13 and declares no requires-python of its own, so
-# it built from source, installed cleanly, and failed at dlopen minutes later.
-# Nothing above 3.12 is tested here; the cap makes uv pick an interpreter that
-# works instead of one that merely satisfies a claim nobody checked.
+# Capped, not open-ended, and the reason is measured rather than assumed.
+#
+# coremltools -- reached through the diarize extra -- publishes macos-arm64
+# wheels for cp38-cp313 only and declares no requires-python of its own, so
+# nothing stops it being selected on a newer interpreter. On 3.14 uv builds its
+# sdist, and the build SUCCEEDS into a `py3-none-any` wheel with the CoreML
+# extensions absent. Nothing raises: `import coremltools` prints "Failed to
+# load '_MLGPUComputeDeviceRemoteProxy'" and carries on, `import senko` is
+# clean, and diarization then does not work -- which diarize.py's fail-soft
+# boundary turns into a transcript quietly missing its speaker labels.
+#
+# Observed on a forced 3.14 install: coremltools 9.0 at `Tag: py3-none-any`,
+# against `Tag: cp312-none-macosx_11_0_arm64` on 3.12.
+#
+# Nothing above 3.12 is tested here, so the open range was a claim nobody
+# checked. tests/test_install_gate.py is what now checks it.
 requires-python = ">=3.12,<3.14"
 license = "AGPL-3.0-only"
 license-files = ["LICENSE"]

--- a/tests/test_diarize.py
+++ b/tests/test_diarize.py
@@ -121,9 +121,9 @@ def test_an_installed_senko_that_will_not_load_says_so(
     package that was already installed, and the dlopen error, which names the
     offending library, thrown away.
 
-    The real instance: `uv tool install` picked Python 3.14 because
-    requires-python had no cap, coremltools publishes no wheel above 3.13, so
-    it built from source and libmodelpackage would not load.
+    This is the general case, not the 3.14 coremltools incident that prompted
+    it -- that one imports clean and loses CoreML silently, and is covered by
+    the requires-python cap and tests/test_install_gate.py instead.
     """
     real_import = builtins.__import__
 

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -1,0 +1,216 @@
+"""The install path the README publishes, executed rather than described.
+
+Every other test in this suite runs against the working tree through `uv run`,
+where `.python-version` pins the interpreter to 3.12 and the extras are already
+synced. That is not how anyone installs jaano. The README tells a stranger to
+run `uv tool install`, which has no project context, reads no
+`.python-version`, and resolves its own interpreter from `requires-python`.
+
+Those two paths diverged and nobody noticed, because nothing executed the
+second one. `uv tool install` picked Python 3.14; coremltools publishes no
+wheel above 3.13 and declares no `requires-python`, so it built from source,
+installed cleanly, and failed to load hours later on a 45-minute recording.
+The suite was green throughout.
+
+So this gate runs the documented command itself, with the extra, and imports
+the thing that broke.
+
+WHY THERE IS NO `skipif` FOR A MISSING senko HERE. tests/test_diarize_gate.py
+skips when the diarize extra is absent, which is correct for a gate about
+diarization quality and is exactly the shape that hid this bug: a check that
+switches itself off in the state it exists to detect. senko being unimportable
+is this gate's failure condition, not its skip condition.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+README = REPO / "README.md"
+
+# The literal line the README publishes, minus the remote. Kept as a pattern
+# rather than a copy so that editing the README's command and not this file is
+# a test failure rather than a silent drift.
+DOCUMENTED = re.compile(
+    r'uv tool install "jaano\[diarize\] @ git\+https://github\.com/m2moiz/jaano"'
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(shutil.which("uv") is None, reason="uv not on PATH"),
+]
+
+
+def _uv(*args: str, tool_dir: Path) -> subprocess.CompletedProcess[str]:
+    """Run uv with an isolated tool directory.
+
+    UV_TOOL_DIR and UV_TOOL_BIN_DIR are what keep this from touching the
+    operator's real `uv tool` installs -- the gate must not be able to clobber
+    a working jaano on the machine running it.
+    """
+    env = os.environ | {
+        "UV_TOOL_DIR": str(tool_dir),
+        "UV_TOOL_BIN_DIR": str(tool_dir / "bin"),
+    }
+    return subprocess.run(
+        ["uv", *args], capture_output=True, text=True, env=env, check=False, timeout=900
+    )
+
+
+def test_the_readme_still_publishes_the_command_this_gate_runs() -> None:
+    """The gate is only worth anything while it tests the published command.
+
+    A cheap fast check that the two have not drifted. If the README's install
+    line changes, this fails and points at the gate below rather than letting
+    it go on verifying a command nobody is told to run.
+    """
+    assert DOCUMENTED.search(README.read_text()), (
+        "the README no longer publishes the install command this gate runs; "
+        "update DOCUMENTED and the gate together"
+    )
+
+
+def test_the_documented_install_produces_a_working_diarizing_jaano(
+    tmp_path: Path,
+) -> None:
+    """Run the README's command, then import the extra that broke.
+
+    The only substitution is the remote: a local `git+file://` clone stands in
+    for github.com, so the gate tests the branch under test rather than
+    whatever is on main. Everything else -- the extra, the resolver, the
+    interpreter choice -- is the published path untouched.
+    """
+    tool_dir = tmp_path / "tools"
+    spec = f'jaano[diarize] @ git+file://{REPO}'
+
+    install = _uv("tool", "install", "--force", spec, tool_dir=tool_dir)
+    assert install.returncode == 0, (
+        f"the documented install failed:\n{install.stdout}\n{install.stderr}"
+    )
+
+    # 1. The console script exists. `uv sync` puts it somewhere nothing can
+    #    reach; this is the difference the README's install section is about.
+    binary = tool_dir / "bin" / "jaano"
+    assert binary.is_file(), f"no jaano executable in {tool_dir / 'bin'}"
+
+    # 2. It runs.
+    helped = subprocess.run(
+        [str(binary), "--help"], capture_output=True, text=True, check=False, timeout=120
+    )
+    assert helped.returncode == 0, helped.stderr
+    assert "dikhao" in helped.stdout
+
+    env_python = tool_dir / "jaano" / "bin" / "python"
+    assert env_python.is_file(), f"no interpreter in the tool env at {env_python}"
+
+    # 3. The interpreter obeys the cap. This is the bug itself: with
+    #    `requires-python = ">=3.12"` uv picked 3.14, where the next assertion
+    #    fails. Checked separately so a future regression says WHICH half broke.
+    version = subprocess.run(
+        [str(env_python), "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    ).stdout.strip()
+    major, minor = (int(part) for part in version.split("."))
+    assert (major, minor) >= (3, 12), f"tool env is on Python {version}, below the floor"
+    assert (major, minor) < (3, 14), (
+        f"tool env is on Python {version}. requires-python let uv pick an "
+        f"interpreter above the cap, which is how coremltools ends up built "
+        f"from source and unloadable."
+    )
+
+    # 4. senko imports. Necessary, and NOT sufficient -- see the next
+    #    assertion, which is the one this file exists for.
+    imported = subprocess.run(
+        [str(env_python), "-c", "import senko; print(senko.__name__)"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert imported.returncode == 0, (
+        f"jaano[diarize] installed on Python {version} and senko will not "
+        f"import:\n{imported.stderr}"
+    )
+
+    # 5. THE ASSERTION THIS FILE EXISTS FOR: coremltools brought its native
+    #    extensions.
+    #
+    #    Measured on a forced 3.14 install: coremltools publishes no wheel for
+    #    that interpreter, so uv builds the sdist -- and the build SUCCEEDS,
+    #    producing a `py3-none-any` wheel with the CoreML extensions simply
+    #    absent. Nothing raises. `import coremltools` prints "Failed to load
+    #    '_MLGPUComputeDeviceRemoteProxy'" to stderr and carries on; `import
+    #    senko` is clean. The install is green, the import is green, and
+    #    diarization then does not work -- which jaano's fail-soft boundary
+    #    turns into a transcript quietly missing its speaker labels.
+    #
+    #    So an import check cannot catch this and a returncode cannot either.
+    #    Root-Is-Purelib is the signal: a real coremltools ships a platform
+    #    wheel, and a gutted one does not.
+    wheel_tag = subprocess.run(
+        [
+            str(env_python),
+            "-c",
+            "import importlib.metadata as m\n"
+            "d = m.distribution('coremltools')\n"
+            "w = d.read_text('WHEEL') or ''\n"
+            "print([ln for ln in w.splitlines() if ln.startswith('Tag:')] or ['Tag: <none>'])",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    assert wheel_tag.returncode == 0, wheel_tag.stderr
+    assert "py3-none-any" not in wheel_tag.stdout, (
+        f"coremltools installed as a pure-Python wheel {wheel_tag.stdout.strip()} on "
+        f"Python {version}: the native CoreML extensions were not built. It will "
+        f"import cleanly and diarization will not run."
+    )
+
+    # 5. And jaano's own boundary agrees. `_import_senko` is what converts a
+    #    load failure into DiarizationUnavailable, and a green import above
+    #    with a raising boundary here would mean the boundary is lying.
+    boundary = subprocess.run(
+        [
+            str(env_python),
+            "-c",
+            "import json\n"
+            "from jaano.diarize import _import_senko\n"
+            "print(json.dumps({'module': _import_senko().__name__}))",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=600,
+    )
+    assert boundary.returncode == 0, (
+        f"senko imports but jaano's diarize boundary still refuses it:\n{boundary.stderr}"
+    )
+    assert json.loads(boundary.stdout)["module"] == "senko"
+
+
+def test_this_gate_runs_on_a_python_the_cap_allows() -> None:
+    """A guard on the guard.
+
+    The assertions above compare the TOOL ENV's interpreter against the cap.
+    If the suite itself is ever run on a Python outside the supported range,
+    that comparison is still valid but the rest of the suite is not, and it
+    should say so once rather than fail obscurely everywhere.
+    """
+    assert (3, 12) <= sys.version_info[:2] < (3, 14), (
+        f"the suite is running on Python {sys.version_info.major}."
+        f"{sys.version_info.minor}, outside pyproject's requires-python"
+    )


### PR DESCRIPTION
Builds the gate — and the gate falsified yesterday's explanation while I was building it.

## The correction

| | |
|---|---|
| **Claimed in #17** | coremltools has no cp314 wheel → uv built from source → `libmodelpackage` failed to `dlopen` → `ImportError` misreported as "not installed" |
| **Measured** | the source build **succeeds** into a `py3-none-any` wheel with the CoreML extensions **absent**. Nothing raises. |

Forced onto 3.14 and compared:

```
broken 3.14 env:   Tag: py3-none-any
healthy 3.12 env:  Tag: cp312-none-macosx_11_0_arm64
```

`import coremltools` prints `Failed to load '_MLGPUComputeDeviceRemoteProxy'` and carries on. `import senko` is clean. Diarization then doesn't work, and the fail-soft boundary turns that into **a transcript quietly missing its speaker labels** — which is exactly what was observed, and why nothing looked broken.

The cap stands, for a corrected reason. The `ImportError` split stands on its own merits — a real load failure *would* have been misreported — but it is not the fix for this incident and no longer claims to be. Comments corrected in `pyproject.toml`, `README.md`, `diarize.py`, `test_diarize.py`.

## The gate

Runs the command the README publishes, only the remote swapped for a local clone, into an isolated `UV_TOOL_DIR`:

1. console script exists (the thing `uv sync` does not give you)
2. it runs
3. the interpreter is inside the cap
4. `import senko` succeeds
5. jaano's own `_import_senko` boundary accepts it
6. **coremltools did not land as a pure-Python wheel**

Assertion 6 is the one that matters — an import check *cannot see* this failure, which is precisely why nothing caught it. Verified both ways: fails on the forced 3.14 env, passes on 3.12.

**No `skipif` for a missing senko.** `test_diarize_gate.py` has one, correctly for a gate about diarization quality — and it's the shape that hid this: a check that switches itself off in the state it exists to detect.

## Why it's a CI job

`just check` gates merges; `just verify` is a session-close ritual that can run *after* one — as it did for #10. CI runs before the merge, and this is the path the README publishes to strangers.

Fast lane unchanged at **221**; all three tests are slow-marked.
