### PR TITLE
chore: point every URL at the renamed repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: ci
 
-# NO LONGER DORMANT. Runs on github.com/m2moiz/jaano since 2026-08-06.
+# NO LONGER DORMANT. Runs on github.com/m2moiz/dekho-suno-jaano since 2026-08-06.
 #
 # The first three runs are why this file could not be trusted until it ran:
 #   1. FAILED in 8s   -- astral-sh/setup-uv@v9 does not resolve (releases go to

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-<a href="https://github.com/m2moiz/jaano/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/m2moiz/jaano/actions/workflows/ci.yml/badge.svg"></a>
+<a href="https://github.com/m2moiz/dekho-suno-jaano/actions/workflows/ci.yml"><img alt="ci" src="https://github.com/m2moiz/dekho-suno-jaano/actions/workflows/ci.yml/badge.svg"></a>
 <a href="pyproject.toml"><img alt="python" src="https://img.shields.io/badge/python-3.12+-blue"></a>
 <a href="#requirements"><img alt="platform" src="https://img.shields.io/badge/platform-Apple%20Silicon-lightgrey"></a>
 <a href="docs/generalisation.md"><img alt="validated" src="https://img.shields.io/badge/validated-834%20recordings%20%C2%B7%20p%3D3.5e--94-brightgreen"></a>
@@ -101,13 +101,13 @@ the interesting part.
 ## Install
 
 ```bash
-uv tool install git+https://github.com/m2moiz/jaano
+uv tool install git+https://github.com/m2moiz/dekho-suno-jaano
 ```
 
 That puts `dsj` on your `PATH`. With speaker labels (see the caveats below):
 
 ```bash
-uv tool install "dsj[diarize] @ git+https://github.com/m2moiz/jaano"
+uv tool install "dsj[diarize] @ git+https://github.com/m2moiz/dekho-suno-jaano"
 ```
 
 Model weights (~2.4 GB) download on first run and are cached by
@@ -118,7 +118,7 @@ command at `.venv/bin/dsj` and links it nowhere, so from a clone every
 invocation is prefixed with `uv run`:
 
 ```bash
-git clone https://github.com/m2moiz/jaano
+git clone https://github.com/m2moiz/dekho-suno-jaano
 cd dsj
 uv sync                      # or: uv sync --extra diarize
 uv run dsj suno recording.mov -o transcript.json
@@ -200,7 +200,7 @@ default.
 It is an extra, because mlx-whisper pulls torch (~250 MB):
 
 ```bash
-uv tool install "dsj[whisper] @ git+https://github.com/m2moiz/jaano"
+uv tool install "dsj[whisper] @ git+https://github.com/m2moiz/dekho-suno-jaano"
 ```
 
 **Long runs.** An hour of audio is not something you sit and watch, so detach it

--- a/dsj/diarize.py
+++ b/dsj/diarize.py
@@ -39,7 +39,7 @@ from dsj.merge import Turn
 # no-op. `uv sync --extra diarize` only means anything inside a clone; someone
 # who ran `uv tool install` has no project to sync and needs the reinstall form.
 INSTALL_HINT = (
-    'uv tool install "dsj[diarize] @ git+https://github.com/m2moiz/jaano"'
+    'uv tool install "dsj[diarize] @ git+https://github.com/m2moiz/dekho-suno-jaano"'
     " (or `uv sync --extra diarize` from a clone)"
 )
 
@@ -49,7 +49,7 @@ INSTALL_HINT = (
 # reproduces the breakage on the same interpreter that caused it.
 REINSTALL_HINT = (
     'uv tool install --force --python 3.12 "dsj[diarize] @ '
-    'git+https://github.com/m2moiz/jaano"'
+    'git+https://github.com/m2moiz/dekho-suno-jaano"'
 )
 
 

--- a/dsj/whisper.py
+++ b/dsj/whisper.py
@@ -47,7 +47,7 @@ DEFAULT_WHISPER_MODEL = "mlx-community/whisper-large-v3-turbo"
 SAMPLE_RATE = 16000
 
 INSTALL_HINT = (
-    'uv tool install "dsj[whisper] @ git+https://github.com/m2moiz/jaano"'
+    'uv tool install "dsj[whisper] @ git+https://github.com/m2moiz/dekho-suno-jaano"'
     " (or `uv sync --extra whisper` from a clone)"
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,9 +45,9 @@ dsj = "dsj.cli:main"
 # An installed copy has no repository beside it. Without these, `pip show dsj`
 # on someone else's machine points nowhere.
 [project.urls]
-Homepage = "https://github.com/m2moiz/jaano"
-Source = "https://github.com/m2moiz/jaano"
-Issues = "https://github.com/m2moiz/jaano/issues"
+Homepage = "https://github.com/m2moiz/dekho-suno-jaano"
+Source = "https://github.com/m2moiz/dekho-suno-jaano"
+Issues = "https://github.com/m2moiz/dekho-suno-jaano/issues"
 
 [project.optional-dependencies]
 # mlx-whisper pulls torch (~250 MB) purely for its torch->mlx weight

--- a/tests/test_install_gate.py
+++ b/tests/test_install_gate.py
@@ -41,7 +41,7 @@ README = REPO / "README.md"
 # rather than a copy so that editing the README's command and not this file is
 # a test failure rather than a silent drift.
 DOCUMENTED = re.compile(
-    r'uv tool install "dsj\[diarize\] @ git\+https://github\.com/m2moiz/jaano"'
+    r'uv tool install "dsj\[diarize\] @ git\+https://github\.com/m2moiz/dekho-suno-jaano"'
 )
 
 pytestmark = [


### PR DESCRIPTION
chore: point every URL at the renamed repository

The repository is now m2moiz/dekho-suno-jaano, so the package, command
and repo finally agree on the name. GitHub redirects the old URL, so
nothing was broken -- but the README install line, the project metadata,
the error-message install hints, the CI comment and the install-gate
regex all published the old address, and a redirect is a dependency on
GitHub keeping it forever. The gate regex and README changed together,
as its drift trip-wire requires.
